### PR TITLE
fix: use temp file for tree entries to avoid argument list overflow

### DIFF
--- a/.github/workflows/write-biorxiv-stats.yml
+++ b/.github/workflows/write-biorxiv-stats.yml
@@ -40,16 +40,17 @@ jobs:
           BRANCH="auto-update-$DATE"
           BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
           BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
-          TREE_ENTRIES="[]"
+          echo '[]' > /tmp/tree_entries.json
           for file in $(git diff --cached --name-only); do
             CONTENT=$(base64 -w0 "$file")
             BLOB_SHA=$(gh api "repos/$REPO/git/blobs" -f content="$CONTENT" -f encoding=base64 --jq '.sha')
-            TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq --arg path "$file" --arg sha "$BLOB_SHA" \
-              '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+            jq --arg path "$file" --arg sha "$BLOB_SHA" \
+              '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]' \
+              /tmp/tree_entries.json > /tmp/tree_entries_tmp.json && mv /tmp/tree_entries_tmp.json /tmp/tree_entries.json
           done
           NEW_TREE=$(gh api "repos/$REPO/git/trees" \
-            --input <(jq -n --arg base "$BASE_TREE" --argjson tree "$TREE_ENTRIES" \
-              '{base_tree: $base, tree: $tree}') --jq '.sha')
+            --input <(jq -n --arg base "$BASE_TREE" --slurpfile tree /tmp/tree_entries.json \
+              '{base_tree: $base, tree: $tree[0]}') --jq '.sha')
           COMMIT_SHA=$(gh api "repos/$REPO/git/commits" \
             --input <(jq -n --arg msg "Updated $OUT_DIR" --arg tree "$NEW_TREE" --arg parent "$BASE_SHA" \
               '{message: $msg, tree: $tree, parents: [$parent]}') --jq '.sha')


### PR DESCRIPTION
## Summary
- Fix `Argument list too long` error in signed commit step
- Replace inline `TREE_ENTRIES` shell variable with `/tmp/tree_entries.json` temp file
- Root cause: many changed files caused base64 content to exceed OS arg limit

## Test plan
- [ ] `workflow_dispatch` after merge — commit step succeeds

Generated with Claude <noreply@anthropic.com>