### PR TITLE
fix: cast biorxiv API total/count to int for pagination

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -58,7 +58,7 @@ def needs_pagination(messages: list) -> bool:
     """Return True when the API total exceeds the current page count."""
     if not messages:
         return False
-    return messages[0]["total"] > messages[0]["count"]
+    return int(messages[0]["total"]) > int(messages[0]["count"])
 
 
 def build_date_range(days: int) -> tuple:


### PR DESCRIPTION
biorxiv API returns `total` and `count` as strings. Adds `int()` cast in `needs_pagination()` to fix `TypeError: '>' not supported`.