### PR TITLE
fix: defensive .get() in needs_pagination for missing keys

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -58,7 +58,10 @@ def needs_pagination(messages: list) -> bool:
     """Return True when the API total exceeds the current page count."""
     if not messages:
         return False
-    return int(messages[0]["total"]) > int(messages[0]["count"])
+    msg = messages[0]
+    total = int(msg.get("total", 0))
+    count = int(msg.get("count", 0))
+    return total > count
 
 
 def build_date_range(days: int) -> tuple:


### PR DESCRIPTION
biorxiv API omits total/count keys on error or empty responses. Uses .get() with default 0.