### PR TITLE
fix: update workflow APP_DIR from app/ to src/

### DIFF
--- a/.github/workflows/write-biorxiv-stats.yml
+++ b/.github/workflows/write-biorxiv-stats.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 env:
   OUT_DIR: './data'
-  APP_DIR: './app'
+  APP_DIR: './src'
   PY_VER: '3.10'
 jobs:
   updateBiorxivCsv:


### PR DESCRIPTION
GITHUB_TOKEN silently dropped workflow changes in PR #10 (needs workflow scope). Applies the app/ → src/ path fix to write-biorxiv-stats.yml.

Generated with Claude <noreply@anthropic.com>