### PR TITLE
fix: grant issues:write so reusable lint workflow can start

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write   # nested 'notify' job in the reusable workflow needs this
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

Every `Lint MD and Links` run since the workflow landed (#56) has had `conclusion: startup_failure`:

> Error calling workflow `qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f...`. The nested job `notify` is requesting `issues: write`, but is only allowed `issues: none`.

The reusable workflow's `notify` job (which posts an issue on lint failure, gated by `notify_on_failure` — default `false`) requires `issues: write`. GitHub validates requested permissions against the caller's grant at workflow startup, regardless of whether the gated job actually runs.

Caller had only `contents: read`. Adding `issues: write` lets the workflow start. The `notify` job stays a no-op since `notify_on_failure` is not passed.

Cherry-picked from Lambda-Biolab/gha-biorxiv-stats-action#14.

## Test plan

- [ ] Next push to main triggers a successful `Lint MD and Links` run instead of `startup_failure`
- [ ] No issues are auto-filed (notify_on_failure stays default false)

Co-Authored-By: Claude <noreply@anthropic.com>