### PR TITLE
chore: pin all workflow actions to full-length SHAs

### DIFF
--- a/.github/workflows/bump-and-release.yaml
+++ b/.github/workflows/bump-and-release.yaml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Bump version (files only, no commit/tag)
         id: bump
-        uses: callowayproject/bump-my-version@1.3.0
+        uses: callowayproject/bump-my-version@e6ecdc3e573698766cd6c2112faeda50bcc2e56a # 1.3.0
         with:
           args: ${{ inputs.bump_type }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
         language: [ 'python' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
 ...

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
       - run: uv sync --frozen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
       - run: uv sync --frozen

--- a/.github/workflows/write-biorxiv-stats.yml
+++ b/.github/workflows/write-biorxiv-stats.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./
         with:
           OUT_DIR: "./data"


### PR DESCRIPTION
## Summary

Pin every \`@vN\` action ref across the workflows to a full-length commit SHA. Universal hygiene against tag-rewriting attacks; required if/when the repo ever flips the "Require actions to be pinned to a full-length commit SHA" policy on.

| Action | SHA | Tag |
| --- | --- | --- |
| \`actions/checkout\` | \`de0fac2e4500dabe0009e67214ff5f5447ce83dd\` | v6.0.2 |
| \`astral-sh/setup-uv\` | \`37802adc94f370d6bfd71619e3f0bf239e1f3b78\` | v7.6.0 |
| \`github/codeql-action/{init,autobuild,analyze}\` | \`e46ed2cbd01164d986452f91f178727624ae40d7\` | v4.35.3 |
| \`callowayproject/bump-my-version\` | \`e6ecdc3e573698766cd6c2112faeda50bcc2e56a\` | 1.3.0 |

Cherry-picked from Lambda-Biolab/gha-biorxiv-stats-action#6. No behavior change.

Co-Authored-By: Claude <noreply@anthropic.com>