### PR TITLE
chore: expand .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,23 @@
-pytest-of-vscode/
+# Python
 __pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+pytest-of-vscode/
+
+# IDE / editor
+.vscode/
+.idea/
+
+# Local env / secrets
+.env
+.env.*
+!.env.example
+
+# Claude Code (project settings.json is committed; .local is per-user)
+.claude/settings.local.json
+MEMORY.md
+
+# OS / shell
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary

Replace the 2-line .gitignore with conventional Python + IDE + secrets + Claude Code + OS entries.

- Python: `.venv/`, `.pytest_cache/`, `*.py[cod]` (existing `__pycache__/` and `pytest-of-vscode/` retained)
- IDE: `.vscode/`, `.idea/`
- Secrets: `.env`, `.env.*` (with `\!.env.example` allow rule)
- Claude Code: `.claude/settings.local.json` (per-user override) and `MEMORY.md` (auto-memory file). Project-level `.claude/settings.json` stays trackable so plugin enablement can be shared.
- OS: `.DS_Store`, `Thumbs.db`

Cherry-picked from Lambda-Biolab/gha-biorxiv-stats-action#5. Harmless if files don't exist locally.

Co-Authored-By: Claude <noreply@anthropic.com>