### PR TITLE
docs: matrix usage example + categories doc cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,45 @@ Logs daily stats of papers submitted to [biorxiv.org](https://www.biorxiv.org/).
 ```yaml
 - uses: qte77/gha-biorxiv-stats-action@v0
   with:
-    OUT_DIR: './data'
-    DAYS: '1'
-    CATEGORIES: 'neuroscience'
-    SERVER: 'biorxiv'
+    OUT_DIR: "./data"
+    DAYS: "1"
+    CATEGORIES: "neuroscience"
+    SERVER: "biorxiv"
     TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+<details>
+<summary>Multi-server matrix (biorxiv + medrxiv)</summary>
+
+```yaml
+strategy:
+  max-parallel: 1   # serialize to avoid concurrent auto-PR merges
+  matrix:
+    include:
+      - server: biorxiv
+        categories: "bioinformatics,microbiology"
+      - server: medrxiv
+        categories: "infectious diseases,genetic and genomic medicine"
+steps:
+  - uses: qte77/gha-biorxiv-stats-action@v0
+    with:
+      OUT_DIR: "./data/${{ matrix.server }}"
+      SERVER: ${{ matrix.server }}
+      CATEGORIES: ${{ matrix.categories }}
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+</details>
 
 ## Inputs
 
 | Name | Required | Default | Description |
-|------|----------|---------|-------------|
-| `OUT_DIR` | No | `./data` | Directory to write CSV output files |
-| `DAYS` | No | `1` | Number of days back to fetch |
-| `CATEGORIES` | No | _(empty)_ | bioRxiv category filter (e.g. neuroscience). Empty for all |
-| `SERVER` | No | `biorxiv` | API server: `biorxiv` or `medrxiv` |
-| `TOKEN` | No | `${{ github.token }}` | GitHub token for pushing changes |
+| ---- | -------- | ------- | ----------- |
+| `OUT_DIR` | No | `./data` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
+| `DAYS` | No | `1` | Number of days back to fetch. |
+| `CATEGORIES` | No | _(empty)_ | Comma-separated categories to keep (case-insensitive). Empty keeps all. Filter applied client-side. See [`docs/categories.md`](docs/categories.md) for per-server taxonomies. |
+| `SERVER` | No | `biorxiv` | API server: `biorxiv` or `medrxiv`. Same `/details/` endpoint, different `server` path segment. |
+| `TOKEN` | No | `${{ github.token }}` | GitHub token for pushing changes. |
 
 ## API
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,11 @@ inputs:
     description: "Number of days back to fetch."
     default: "1"
   CATEGORIES:
-    description: "bioRxiv category filter (e.g. neuroscience). Empty for all."
+    description: >-
+      Comma-separated bioRxiv categories to keep (case-insensitive). Empty
+      keeps all. Filtering is applied client-side after fetching the full
+      date range, since the bioRxiv /details/ API has no server-side
+      category filter.
     default: ""
   SERVER:
     description: "API server: biorxiv or medrxiv."

--- a/docs/categories.md
+++ b/docs/categories.md
@@ -1,0 +1,124 @@
+# Server categories
+
+Reference list of subject categories per preprint server. Used to choose
+sensible defaults for the `CATEGORIES` action input.
+
+Status legend:
+
+- **canonical** — full list, verified
+- **sampled** — partial; needs full pagination from a longer-lived runner
+- **unreachable** — blocked from CI sandbox; re-run elsewhere
+
+## bioRxiv (canonical, 25)
+
+Source: `https://api.biorxiv.org/details/biorxiv/{date1}/{date2}/{cursor}/json`
+
+```text
+animal behavior and cognition
+biochemistry
+bioengineering
+bioinformatics
+biophysics
+cancer biology
+cell biology
+developmental biology
+ecology
+evolutionary biology
+genetics
+genomics
+immunology
+microbiology
+molecular biology
+neuroscience
+paleontology
+pathology
+pharmacology and toxicology
+physiology
+plant biology
+scientific communication and education
+synthetic biology
+systems biology
+zoology
+```
+
+## medRxiv (sampled, 29 observed; ~35–45 expected)
+
+Source: `https://api.biorxiv.org/details/medrxiv/{date1}/{date2}/{cursor}/json`
+
+Pagination timed out from the enumeration sandbox after the first few pages.
+This list is the union of one 1-week window and one partial 1-year window.
+Re-run from a CI runner with longer timeouts to converge.
+
+```text
+addiction medicine
+allergy and immunology
+cardiovascular medicine
+dentistry and oral medicine
+dermatology
+endocrinology
+epidemiology
+forensic medicine
+genetic and genomic medicine
+geriatric medicine
+health economics
+health informatics
+health policy
+health systems and quality improvement
+infectious diseases
+intensive care and critical care medicine
+medical education
+nephrology
+neurology
+nutrition
+obstetrics and gynecology
+occupational and environmental health
+oncology
+ophthalmology
+pain medicine
+pathology
+pediatrics
+pharmacology and therapeutics
+psychiatry and clinical psychology
+public and global health
+radiology and imaging
+rehabilitation medicine and physical therapy
+respiratory medicine
+sexual and reproductive health
+sports medicine
+surgery
+```
+
+## psyArXiv (canonical, 6 top-level; 234 total OSF taxonomy nodes)
+
+Source: `https://api.osf.io/v2/preprint_providers/psyarxiv/taxonomies/`
+
+Top-level (recommended for `CATEGORIES` filter — the full 234-node taxonomy
+is too granular for a coarse filter):
+
+```text
+Engineering Psychology
+Life Sciences
+Meta-science
+Neuroscience
+Psychiatry
+Social and Behavioral Sciences
+```
+
+The 228 depth-1 children include `Cognitive Neuroscience`, `Clinical
+Psychology`, `Behavioral Economics`, `Computational Modeling`, and similar.
+Fetch the full list via the source URL above when implementing.
+
+## chemRxiv (unreachable, pending)
+
+Source: `https://chemrxiv.org/engage/chemrxiv/public-api/v1/items` (categories
+embedded in item records)
+
+The chemRxiv public API is fronted by Cloudflare and returns a challenge page
+to non-browser clients from the enumeration sandbox. Approaches that work:
+
+- run the fetch from a real browser DevTools session (paste cookies into a
+  `curl` invocation)
+- run from a CI runner where Cloudflare flags a verified UA
+- use the official client library if/when one ships
+
+Tracked in [issue #69](https://github.com/qte77/gha-biorxiv-stats-action/issues/69).

--- a/src/app.py
+++ b/src/app.py
@@ -10,17 +10,22 @@ from utils import (
     load_all_existing_ids,
     needs_pagination,
     parse_biorxiv_json,
+    prune_existing_csvs,
     write_file,
 )
 
 OUT_DIR = getenv("OUT_DIR", "./data")
 DAYS = int(getenv("DAYS", "1"))
-CATEGORIES = getenv("CATEGORIES", "")
+CATEGORIES = {c.strip() for c in getenv("CATEGORIES", "").split(",") if c.strip()}
 SERVER = getenv("SERVER", "biorxiv")  # biorxiv or medrxiv
 
 HEADER = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"]
 PAGE_SIZE = 100
 BASE_URL = f"https://api.biorxiv.org/details/{SERVER}"
+
+pruned = prune_existing_csvs(OUT_DIR, CATEGORIES)
+if pruned:
+    print(f"Pruned {pruned} rows outside CATEGORIES from {OUT_DIR}")
 
 existing_ids = load_all_existing_ids(OUT_DIR)
 print(f"Loaded {len(existing_ids)} existing paper IDs from {OUT_DIR}")
@@ -34,14 +39,12 @@ def main() -> None:
 
     while True:
         url = f"{BASE_URL}/{start_date}/{end_date}/{cursor}/json"
-        if CATEGORIES:
-            url = f"{url}?category={CATEGORIES}"
 
         data = get_api_response(url)
         payload = json.loads(data)
         messages = payload.get("messages", [])
 
-        weekly = parse_biorxiv_json(data)
+        weekly = parse_biorxiv_json(data, CATEGORIES)
         for week, rows in weekly.items():
             all_weeks.setdefault(week, []).extend(rows)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -35,15 +35,22 @@ def get_api_response(url: str, max_retries: int = 3, backoff_base: float = 2.0) 
                 ) from None
 
 
-def parse_biorxiv_json(data: bytes) -> dict:
+def parse_biorxiv_json(data: bytes, categories: set | None = None) -> dict:
     """Parse bioRxiv JSON bytes, return dict keyed by (year, week) tuple.
 
     Each value is a list of rows:
     [Date, ISOWeek, DOI, Version, Category, Title, Authors]
+
+    If ``categories`` is a non-empty set, entries whose category is not in the
+    set are discarded (case-insensitive match on the bioRxiv category string).
     """
     payload = json.loads(data)
     out: dict = {}
+    cat_filter = {c.strip().lower() for c in categories} if categories else None
     for entry in payload.get("collection", []):
+        cat = entry.get("category", "")
+        if cat_filter and cat.strip().lower() not in cat_filter:
+            continue
         pub_date = entry["date"]  # YYYY-MM-DD
         iso = date.fromisoformat(pub_date).isocalendar()
         key = (iso[0], iso[1])  # (year, week)
@@ -55,7 +62,7 @@ def parse_biorxiv_json(data: bytes) -> dict:
                 iso[1],
                 entry.get("doi", ""),
                 entry.get("version", ""),
-                entry.get("category", ""),
+                cat,
                 entry.get("title", ""),
                 entry.get("authors", ""),
             ]
@@ -109,6 +116,38 @@ def load_all_existing_ids(data_dir):
             if fname.endswith(".csv"):
                 existing.update(_load_existing_ids(os.path.join(subdir, fname)))
     return existing
+
+
+def prune_existing_csvs(data_dir: str, categories: set | None) -> int:
+    """Rewrite each CSV in data_dir/YYYY/ keeping only rows whose Category is
+    in the set (case-insensitive). Returns total rows removed. No-op when
+    categories is empty/None.
+    """
+    if not categories or not exists(data_dir):
+        return 0
+    cat_filter = {c.strip().lower() for c in categories}
+    removed = 0
+    for entry in os.listdir(data_dir):
+        subdir = os.path.join(data_dir, entry)
+        if not os.path.isdir(subdir) or not entry.isdigit():
+            continue
+        for fname in os.listdir(subdir):
+            if not fname.endswith(".csv"):
+                continue
+            path = os.path.join(subdir, fname)
+            with open(path, newline="", encoding="UTF8") as f:
+                rows = list(csv.reader(f))
+            if not rows:
+                continue
+            header, *body = rows
+            kept = [r for r in body if len(r) >= 5 and r[4].strip().lower() in cat_filter]
+            if len(kept) != len(body):
+                removed += len(body) - len(kept)
+                with open(path, "w", newline="", encoding="UTF8") as f:
+                    w = csv.writer(f)
+                    w.writerow(header)
+                    w.writerows(kept)
+    return removed
 
 
 def filter_new_rows(rows, existing_ids):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from src.utils import (
     load_all_existing_ids,
     needs_pagination,
     parse_biorxiv_json,
+    prune_existing_csvs,
     write_file,
 )
 
@@ -86,6 +87,85 @@ def test_parse_biorxiv_json():
     assert first[0] == "2024-01-15"
     assert first[1] == 3
     assert first[2] == "10.1101/2024.01.15.1234"
+
+
+def test_parse_biorxiv_json_filters_by_category():
+    """Entries outside the categories set are dropped (case-insensitive)."""
+    data = json.dumps(
+        {
+            "messages": [{"status": "ok", "total": 3, "count": 3}],
+            "collection": [
+                {
+                    "doi": "10.1101/a",
+                    "version": "1",
+                    "category": "Bioinformatics",
+                    "title": "Keep",
+                    "authors": "A",
+                    "date": "2024-01-15",
+                },
+                {
+                    "doi": "10.1101/b",
+                    "version": "1",
+                    "category": "neuroscience",
+                    "title": "Drop",
+                    "authors": "B",
+                    "date": "2024-01-15",
+                },
+                {
+                    "doi": "10.1101/c",
+                    "version": "1",
+                    "category": "microbiology",
+                    "title": "Keep",
+                    "authors": "C",
+                    "date": "2024-01-15",
+                },
+            ],
+        }
+    ).encode()
+    result = parse_biorxiv_json(data, {"bioinformatics", "microbiology"})
+    rows = result[(2024, 3)]
+    dois = {row[2] for row in rows}
+    assert dois == {"10.1101/a", "10.1101/c"}
+
+
+def test_parse_biorxiv_json_no_filter_keeps_all():
+    """Empty/None category filter keeps every entry."""
+    result_none = parse_biorxiv_json(FIXTURE_JSON, None)
+    result_empty = parse_biorxiv_json(FIXTURE_JSON, set())
+    assert len(result_none[(2024, 3)]) == 2
+    assert len(result_empty[(2024, 3)]) == 2
+
+
+def test_prune_existing_csvs_drops_outside_set(tmp_path):
+    """Rewrites CSVs to keep only rows whose Category is in the set."""
+    header = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"]
+    (tmp_path / "2024").mkdir()
+    p = tmp_path / "2024" / "3.csv"
+    with open(p, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerow(["2024-01-15", 3, "10.1101/a", "1", "Bioinformatics", "K", "X"])
+        w.writerow(["2024-01-15", 3, "10.1101/b", "1", "neuroscience", "D", "Y"])
+        w.writerow(["2024-01-15", 3, "10.1101/c", "1", "microbiology", "K", "Z"])
+    removed = prune_existing_csvs(str(tmp_path), {"bioinformatics", "microbiology"})
+    assert removed == 1
+    with open(p) as f:
+        kept = list(csv.DictReader(f))
+    assert {r["DOI"] for r in kept} == {"10.1101/a", "10.1101/c"}
+
+
+def test_prune_existing_csvs_noop_when_empty(tmp_path):
+    """Empty/None category set leaves CSVs untouched."""
+    (tmp_path / "2024").mkdir()
+    p = tmp_path / "2024" / "3.csv"
+    with open(p, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"])
+        w.writerow(["2024-01-15", 3, "10.1101/a", "1", "neuroscience", "T", "X"])
+    before = p.read_bytes()
+    assert prune_existing_csvs(str(tmp_path), set()) == 0
+    assert prune_existing_csvs(str(tmp_path), None) == 0
+    assert p.read_bytes() == before
 
 
 def test_pagination_detection():


### PR DESCRIPTION
## Summary

Stacks on #76 (filter + categories doc).

- Add a collapsible `<details>` block under **Usage** showing the `strategy.matrix` pattern for fetching biorxiv + medrxiv with one workflow (`max-parallel: 1` to avoid concurrent auto-PR races, per-server `OUT_DIR`).
- Pad the inputs-table separator pipes for markdownlint MD060 compliance.
- Cross-link `CATEGORIES` description to `docs/categories.md` (added in #76).
- Tighten `OUT_DIR` description to mention the `./data/<server>` convention (default unchanged for backward compat).

No code change.

## Order

Land #76 first; this PR will need a small rebase otherwise (the categories-doc reference would dangle).

Co-Authored-By: Claude <noreply@anthropic.com>