### PR TITLE
chore: update repo references to gha-rxiv-stats-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Renamed
+
+- Repo `gha-biorxiv-stats-action` → `gha-rxiv-stats-action` to reflect
+  multi-server scope (bioRxiv + medRxiv today; chemRxiv, psyArXiv,
+  arXiv pending — see #69, #70, #72). GitHub auto-redirects old URLs;
+  in-repo references (README badges, Usage, action.yaml `name`)
+  updated (#78).
+
+### Added
+
+- Client-side `CATEGORIES` filter in `parse_biorxiv_json` (the
+  bioRxiv `/details/` API has no server-side category filter, so the
+  prior `?category=` URL query was a silent no-op) (#76).
+- `prune_existing_csvs()` rewrites historical CSVs on each run so
+  rows outside the current category set are dropped retroactively (#76).
+- `docs/categories.md` documenting per-server taxonomies (bioRxiv
+  canonical 25, medRxiv sampled 29; chemRxiv and psyArXiv tracked as
+  separate fetcher work in #69 and #70) (#76).
+- README inline `strategy.matrix` example for fetching biorxiv +
+  medrxiv with a single workflow (#77).
+
+### Changed
+
+- All workflow actions pinned to full-length commit SHAs:
+  `actions/checkout` → `de0fac2` (v6.0.2),
+  `astral-sh/setup-uv` → `37802ad` (v7.6.0),
+  `github/codeql-action/*` → `e46ed2c` (v4.35.3),
+  `callowayproject/bump-my-version` → `e6ecdc3` (1.3.0) (#74).
+- Expanded `.gitignore` (Python, IDE, secrets, Claude per-user, OS
+  patterns) (#75).
+- README inputs table cross-links `CATEGORIES` to
+  `docs/categories.md` and notes the `./data/<server>` convention for
+  multi-server use (#77).
+- README tagline updated to mention bioRxiv + medRxiv; API section
+  lists both URLs (#78).
+
+### Fixed
+
+- `Lint MD and Links` workflow no longer fails at startup with
+  `issues: write` permission missing for the reusable workflow's
+  nested `notify` job (#73).
+
 ---
 
 ## [0.1.0] - 2026-03-29

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# gha-biorxiv-stats-action
+# gha-rxiv-stats-action
 
-Logs daily stats of papers submitted to [biorxiv.org](https://www.biorxiv.org/).
+Logs stats of papers submitted to [bioRxiv](https://www.biorxiv.org/)
+and [medRxiv](https://www.medrxiv.org/) for selected categories. Cron
+cadence is set by the calling workflow.
 
 ![Version](https://img.shields.io/badge/version-0.1.0-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Update biorxiv.org stats](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/write-biorxiv-stats.yml/badge.svg)](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/write-biorxiv-stats.yml)
-[![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-biorxiv-stats-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-biorxiv-stats-action)
-[![CodeQL](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/codeql.yml)
-[![Dependabot](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/dependabot/dependabot-updates)
-[![Ruff](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/ruff.yml/badge.svg)](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/ruff.yml)
-[![Tests](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/test.yml/badge.svg)](https://github.com/qte77/gha-biorxiv-stats-action/actions/workflows/test.yml)
+[![Update biorxiv.org stats](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/write-biorxiv-stats.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/write-biorxiv-stats.yml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action)
+[![CodeQL](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml)
+[![Dependabot](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates)
+[![Ruff](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/ruff.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/ruff.yml)
+[![Tests](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/test.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/test.yml)
 
 ## What it does
 
@@ -22,7 +24,7 @@ Logs daily stats of papers submitted to [biorxiv.org](https://www.biorxiv.org/).
 ## Usage
 
 ```yaml
-- uses: qte77/gha-biorxiv-stats-action@v0
+- uses: qte77/gha-rxiv-stats-action@v0
   with:
     OUT_DIR: './data'
     DAYS: '1'
@@ -43,7 +45,13 @@ Logs daily stats of papers submitted to [biorxiv.org](https://www.biorxiv.org/).
 
 ## API
 
-Data sourced from `https://api.biorxiv.org/details/{server}/{date1}/{date2}/{cursor}/json`.
+Data sourced from:
+
+- bioRxiv: `https://api.biorxiv.org/details/biorxiv/{date1}/{date2}/{cursor}/json`
+- medRxiv: `https://api.biorxiv.org/details/medrxiv/{date1}/{date2}/{cursor}/json`
+
+Both share the same CSHL endpoint, distinguished by the `{server}`
+path segment.
 
 ## License
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
-name: "bioRxiv Stats Action"
-description: "Log daily stats of papers submitted to biorxiv.org or medrxiv.org for selected categories."
+name: "rxiv Stats Action"
+description: "Log stats of papers submitted to biorxiv.org or medrxiv.org for selected categories."
 author: "qte77"
 branding:
   icon: "file-text"


### PR DESCRIPTION
## Summary

Repo renamed `gha-biorxiv-stats-action` → `gha-rxiv-stats-action`. GitHub auto-redirects URLs but in-repo references should match:

- `README.md` title + 6 badge URLs + Usage `uses:` line
- `action.yaml` `name: "bioRxiv Stats Action"` → `"rxiv Stats Action"`; drop "daily" from description (cron cadence is set by the calling workflow, not the action)

Tracked alongside the multi-server consolidation: #69 (chemRxiv), #70 (psyArXiv), #72 (arXiv migration).

Co-Authored-By: Claude <noreply@anthropic.com>