### PR TITLE
chore: finish #78 rename — pyproject + categories.md link

### DIFF
--- a/docs/categories.md
+++ b/docs/categories.md
@@ -121,4 +121,4 @@ to non-browser clients from the enumeration sandbox. Approaches that work:
 - run from a CI runner where Cloudflare flags a verified UA
 - use the official client library if/when one ships
 
-Tracked in [issue #69](https://github.com/qte77/gha-biorxiv-stats-action/issues/69).
+Tracked in [issue #69](https://github.com/qte77/gha-rxiv-stats-action/issues/69).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "gha-biorxiv-stats-action"
+name = "gha-rxiv-stats-action"
 version = "0.1.0"
 description = "Log daily stats of papers submitted to biorxiv.org"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ wheels = [
 ]
 
 [[package]]
-name = "gha-biorxiv-stats-action"
+name = "gha-rxiv-stats-action"
 version = "0.1.0"
 source = { virtual = "." }
 


### PR DESCRIPTION
## Summary

Two leftovers from the repo rename in #78 that #78 didn't sweep:

- `pyproject.toml` package name still said `gha-biorxiv-stats-action` (uv.lock regenerated to follow)
- `docs/categories.md` issue #69 link still pointed at `qte77/gha-biorxiv-stats-action/issues/69`

## Out of scope (intentionally)

- `CHANGELOG.md:16` mentions the old name — that's a historical record of the rename itself; leave it.
- `README.md:49` had a stale `uses: qte77/gha-biorxiv-stats-action@v0` — already fixed in #80; this PR doesn't touch it to avoid conflicts.
- `pyproject.toml` `description` field still says "Log daily stats of papers submitted to biorxiv.org" — separate wording concern (covered by #81's "drop stats" theme); not renamed here to keep this PR strictly about the repo-name rename.

## Test plan

- [x] `pytest tests/` passes locally (14/14) after `uv lock` regeneration
- [ ] No remaining `gha-biorxiv-stats-action` references after this + #80 merge (only the historical CHANGELOG entry stays)

## Independent of #80 / #81

Branched from `main`; no dependency on either of the open PRs. Can land in any order.

Generated with Claude <noreply@anthropic.com>