### PR TITLE
chore: rename workflow to update-rxiv-feed (drop 'stats')

### DIFF
--- a/.github/workflows/update-rxiv-feed.yaml
+++ b/.github/workflows/update-rxiv-feed.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update rxiv stats
+name: Update rxiv feed
 on:
   schedule:
     - cron: "0 1 * * 1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gha-rxiv-stats-action
 
-Logs stats of papers submitted to [bioRxiv](https://www.biorxiv.org/)
+Logs a weekly CSV feed of papers submitted to [bioRxiv](https://www.biorxiv.org/)
 and [medRxiv](https://www.medrxiv.org/) for selected categories. Cron
 cadence is set by the calling workflow.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cadence is set by the calling workflow.
 
 ![Version](https://img.shields.io/badge/version-0.1.0-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Update rxiv stats](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/write-rxiv-stats.yaml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/write-rxiv-stats.yaml)
+[![Update rxiv feed](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/update-rxiv-feed.yaml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/update-rxiv-feed.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action)
 [![CodeQL](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml)
 [![Dependabot](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates)

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
-name: "rxiv Stats Action"
-description: "Log stats of papers submitted to biorxiv.org or medrxiv.org for selected categories."
+name: "rxiv Feed Action"
+description: "Log a weekly CSV feed of papers submitted to biorxiv.org or medrxiv.org for selected categories."
 author: "qte77"
 branding:
   icon: "file-text"


### PR DESCRIPTION
## Summary

Replaces #81 (auto-closed when its base `feat/matrix-rxiv-workflow` was deleted on PR #80 squash-merge).

Drops "stats" wording from user-facing labels — the action emits a weekly CSV stream of paper metadata (DOI, title, authors, category), not aggregate statistics.

- `write-rxiv-stats.yaml` → `update-rxiv-feed.yaml` (file + workflow `name:` + README badge)
- `action.yaml` `name:` → "rxiv Feed Action", `description:` → "weekly CSV feed"
- README tagline updated

## Commits (by topic)

1. `chore: rename workflow to update-rxiv-feed.yaml` — file rename + workflow `name:` + badge
2. `docs: drop misleading 'stats' wording from action description` — `action.yaml` + README tagline

## Out of scope (intentionally)

- **Repo rename** (`gha-rxiv-stats-action` → feed-y) — deferred until the multi-server consolidation in #72 lands, to avoid two consumer-breaking `uses:` renames in two weeks.
- **Source docstrings / CHANGELOG** — internal / historical, not user-facing.

## Test plan

- [x] Existing pytest suite (14/14)
- [x] `.lycheeignore` (added in #80) covers the new badge URL — no link-check 404 expected
- [ ] After merge: badge in README points at `update-rxiv-feed.yaml` and renders; Actions UI shows "Update rxiv feed"

Generated with Claude <noreply@anthropic.com>