### PR TITLE
chore: change OUT_DIR default to ./data/biorxiv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-server use (#77).
 - README tagline updated to mention bioRxiv + medRxiv; API section
   lists both URLs (#78).
+- `OUT_DIR` default in `action.yaml` and the Python fallback in
+  `src/app.py` changed from `./data` to `./data/biorxiv` to match the
+  per-server output convention enforced by the workflow matrix. The
+  matrix always overrides `OUT_DIR` per server, so in-repo behaviour is
+  unchanged; ad-hoc consumers omitting `OUT_DIR` now get output at
+  `./data/biorxiv` (consistent with `SERVER` defaulting to `biorxiv`).
+  README usage example and inputs table updated accordingly (#86).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cadence is set by the calling workflow.
 ```yaml
 - uses: qte77/gha-rxiv-stats-action@v0
   with:
-    OUT_DIR: "./data"
+    OUT_DIR: "./data/biorxiv"
     DAYS: "1"
     CATEGORIES: "neuroscience"
     SERVER: "biorxiv"
@@ -60,7 +60,7 @@ steps:
 
 | Name | Required | Default | Description |
 | ---- | -------- | ------- | ----------- |
-| `OUT_DIR` | No | `./data` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
+| `OUT_DIR` | No | `./data/biorxiv` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
 | `DAYS` | No | `1` | Number of days back to fetch. |
 | `CATEGORIES` | No | _(empty)_ | Comma-separated categories to keep (case-insensitive). Empty keeps all. Filter applied client-side. See [`docs/categories.md`](docs/categories.md) for per-server taxonomies. |
 | `SERVER` | No | `biorxiv` | API server: `biorxiv` or `medrxiv`. Same `/details/` endpoint, different `server` path segment. |

--- a/action.yaml
+++ b/action.yaml
@@ -7,8 +7,10 @@ branding:
   color: "green"
 inputs:
   OUT_DIR:
-    description: "Directory to write CSV output files."
-    default: "./data"
+    description: >-
+      Directory to write CSV output files. Convention: ./data/<server>
+      (e.g. ./data/biorxiv) so multiple servers can coexist without colliding.
+    default: "./data/biorxiv"
   DAYS:
     description: "Number of days back to fetch."
     default: "1"

--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,7 @@ from utils import (
     write_file,
 )
 
-OUT_DIR = getenv("OUT_DIR", "./data")
+OUT_DIR = getenv("OUT_DIR", "./data/biorxiv")
 DAYS = int(getenv("DAYS", "1"))
 CATEGORIES = {c.strip() for c in getenv("CATEGORIES", "").split(",") if c.strip()}
 SERVER = getenv("SERVER", "biorxiv")  # biorxiv or medrxiv


### PR DESCRIPTION
## Summary
- Changes the default value of `OUT_DIR` in `action.yaml` and the Python-side fallback in `src/app.py` from `./data` to `./data/biorxiv`.
- Updates the README usage example and inputs table accordingly.
- Mirrors the convention adopted by the Lambda-Biolab downstream fork and prepares the per-server layout used by issues #69, #70, #72.

## Behaviour
- No change for the in-repo cron workflow — the matrix at `.github/workflows/update-rxiv-feed.yaml` always overrides `OUT_DIR` per server.
- Ad-hoc consumers omitting `OUT_DIR` now get output at `./data/biorxiv` (consistent with `SERVER` defaulting to `biorxiv`).

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest` — 14 passed
- [ ] CI Lint, Tests, Lint MD and Links, CodeQL all green

Generated with Claude <noreply@anthropic.com>