### PR TITLE
feat: arxiv-first defaults + SERVER dispatch in app.py (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-05-15
+
+### Added
+
+- `SERVER=arxiv` dispatch in `src/app.py` exposing arXiv as a first-class
+  fetcher alongside bioRxiv/medRxiv. Closes #72.
+- New action inputs `TOPICS`, `INCLUDE_CITATIONS`, `SEMANTIC_SCHOLAR_API_KEY`,
+  `MAX_AGE_DAYS`, `DATE_FROM`, `DATE_TO`, `PAGE_SIZE`, `MAX_PAGES` —
+  arxiv-specific; ignored for bioRxiv/medRxiv runs.
+
+### Changed
+
+- **BREAKING**: `SERVER` default flipped from `biorxiv` to `arxiv`.
+  Consumers omitting `SERVER` in their workflow will silently switch
+  from bioRxiv to arXiv. Pin `@v0.1.0` to keep the bioRxiv default.
+- **BREAKING**: `OUT_DIR` default flipped from `./data` to `./data/arxiv`.
+- `src/app.py` rewritten: side-effect-free at module level (all env
+  reading + filesystem + network moved into `main()` / `_run_*`
+  helpers). Imports use `src.fetchers.*` / `src.validation` so the same
+  module works in pytest and at runtime; `action.yaml` PYTHONPATH
+  adjusted to `${{ github.action_path }}` (was `.../src`).
+- README usage example now leads with arxiv (no explicit inputs needed);
+  bioRxiv/medRxiv moved into separate subsections.
+- `docs/categories.md` reordered arxiv-first with the canonical arXiv
+  taxonomy (20 top-level groups) and `TOPICS` default rationale.
+
 ### Security
+
+### Renamed
 
 - HTTP URL validation hardened in `src/utils.py`: scheme is parsed
   (not prefix-matched), userinfo (`user:pass@host`) is rejected to

--- a/README.md
+++ b/README.md
@@ -1,86 +1,112 @@
 # gha-rxiv-stats-action
 
-Logs a weekly CSV feed of papers submitted to [bioRxiv](https://www.biorxiv.org/)
-and [medRxiv](https://www.medrxiv.org/) for selected categories. Cron
-cadence is set by the calling workflow.
+Logs a weekly CSV feed of papers submitted to [arXiv](https://arxiv.org/),
+[bioRxiv](https://www.biorxiv.org/), and [medRxiv](https://www.medrxiv.org/)
+for selected categories. Cron cadence is set by the calling workflow.
 
-![Version](https://img.shields.io/badge/version-0.1.0-8A2BE2)
+![Version](https://img.shields.io/badge/version-0.2.0-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Update rxiv feed](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/update-rxiv-feed.yaml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/update-rxiv-feed.yaml)
-[![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-rxiv-stats-action)
-[![CodeQL](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/codeql.yml)
-[![Dependabot](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/dependabot/dependabot-updates)
-[![Ruff](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/ruff.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/ruff.yml)
-[![Tests](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/test.yml/badge.svg)](https://github.com/qte77/gha-rxiv-stats-action/actions/workflows/test.yml)
+[![Update rxiv feed](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/update-rxiv-feed.yaml/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/update-rxiv-feed.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-rxiv-feed-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-rxiv-feed-action)
+[![CodeQL](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/codeql.yml/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/codeql.yml)
+[![Dependabot](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/dependabot/dependabot-updates)
+[![Ruff](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/ruff.yml/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/ruff.yml)
+[![Tests](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/test.yml/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/test.yml)
 
 ## What it does
 
 1. Checks out the calling repository
 2. Sets up Python via uv
-3. Fetches paper stats from the bioRxiv/medRxiv API for the configured categories and date range
-4. Writes results to CSV files in the output directory
+3. Fetches paper stats from the selected `SERVER` (arXiv by default; bioRxiv or medRxiv on request)
+4. Writes results to CSV files in `./data/<server>/`
 5. Opens a PR with the updated data (auto-merges via squash)
 
 ## Usage
 
+Default: fetch the last week of arXiv submissions in CS/AI categories.
+
 ```yaml
-- uses: qte77/gha-rxiv-stats-action@v0
+- uses: qte77/gha-rxiv-feed-action@v0
   with:
-    OUT_DIR: "./data"
-    DAYS: "1"
-    CATEGORIES: "neuroscience"
-    SERVER: "biorxiv"
     TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-<details>
-<summary>Multi-server matrix (biorxiv + medrxiv)</summary>
+### arXiv with custom topics + citation enrichment
+
+```yaml
+- uses: qte77/gha-rxiv-feed-action@v0
+  with:
+    TOPICS: "cat:cs.CV+OR+cat:cs.LG"
+    INCLUDE_CITATIONS: "true"
+    SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_KEY }}
+    TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### bioRxiv / medRxiv
+
+```yaml
+- uses: qte77/gha-rxiv-feed-action@v0
+  with:
+    SERVER: "biorxiv"
+    OUT_DIR: "./data/biorxiv"
+    CATEGORIES: "neuroscience,bioinformatics"
+    TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Multi-server matrix
 
 ```yaml
 strategy:
   max-parallel: 1   # serialize to avoid concurrent auto-PR merges
   matrix:
     include:
+      - server: arxiv
+        topics: "cat:cs.CV+OR+cat:cs.LG"
       - server: biorxiv
         categories: "bioinformatics,microbiology"
       - server: medrxiv
         categories: "infectious diseases,genetic and genomic medicine"
 steps:
-  - uses: qte77/gha-rxiv-stats-action@v0
+  - uses: qte77/gha-rxiv-feed-action@v0
     with:
       OUT_DIR: "./data/${{ matrix.server }}"
       SERVER: ${{ matrix.server }}
+      TOPICS: ${{ matrix.topics }}
       CATEGORIES: ${{ matrix.categories }}
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-</details>
 
 ## Inputs
 
 | Name | Required | Default | Description |
 | ---- | -------- | ------- | ----------- |
-| `OUT_DIR` | No | `./data` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
-| `DAYS` | No | `1` | Number of days back to fetch. |
-| `CATEGORIES` | No | _(empty)_ | Comma-separated categories to keep (case-insensitive). Empty keeps all. Filter applied client-side. See [`docs/categories.md`](docs/categories.md) for per-server taxonomies. |
-| `SERVER` | No | `biorxiv` | API server: `biorxiv` or `medrxiv`. Same `/details/` endpoint, different `server` path segment. |
+| `SERVER` | No | `arxiv` | API server: `arxiv`, `biorxiv`, or `medrxiv`. |
+| `OUT_DIR` | No | `./data/arxiv` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
+| `TOPICS` | No | `cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO` | arXiv search_query (URL-encoded, OR-joined). See [`docs/categories.md`](docs/categories.md#arxiv). arXiv only. |
+| `INCLUDE_CITATIONS` | No | `false` | Enrich arXiv rows with Semantic Scholar citation counts. arXiv only. |
+| `SEMANTIC_SCHOLAR_API_KEY` | No | _(empty)_ | Optional Semantic Scholar API key for higher rate limits. arXiv only. |
+| `MAX_AGE_DAYS` | No | `7` | Skip arXiv papers published more than N days ago. Ignored when `DATE_FROM` is set. arXiv only. |
+| `DATE_FROM` | No | _(empty)_ | YYYY-MM-DD lower bound on arXiv `submittedDate`. arXiv only. |
+| `DATE_TO` | No | _(empty)_ | YYYY-MM-DD upper bound on arXiv `submittedDate`. Empty = today. arXiv only. |
+| `PAGE_SIZE` | No | `1000` | arXiv pagination page size. arXiv only. |
+| `MAX_PAGES` | No | `5` | Cap on arXiv pagination pages per run. arXiv only. |
+| `DAYS` | No | `1` | Number of days back to fetch. bioRxiv/medRxiv only. |
+| `CATEGORIES` | No | _(empty)_ | Comma-separated bioRxiv/medRxiv categories to keep. See [`docs/categories.md`](docs/categories.md). bioRxiv/medRxiv only. |
 | `TOKEN` | No | `${{ github.token }}` | GitHub token for pushing changes. |
 
 ## API
 
 Data sourced from:
 
+- arXiv: `https://export.arxiv.org/api/query?search_query={topics}&start={n}&max_results={k}&sortBy=submittedDate` (Atom XML)
 - bioRxiv: `https://api.biorxiv.org/details/biorxiv/{date1}/{date2}/{cursor}/json`
 - medRxiv: `https://api.biorxiv.org/details/medrxiv/{date1}/{date2}/{cursor}/json`
-
-Both share the same CSHL endpoint, distinguished by the `{server}`
-path segment.
 
 Outbound requests are locked to an allowlist of API hosts
 (`api.biorxiv.org`, `export.arxiv.org`, `api.semanticscholar.org`) and
 require HTTPS on port 443; non-allowlisted hosts raise `ValueError` at
-the validator boundary. Extend `_ALLOWED_HOSTS` in `src/utils.py` when
-adding a new fetcher.
+the validator boundary. Extend `_ALLOWED_HOSTS` in
+`src/fetchers/common.py` when adding a new fetcher.
 
 ## License
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,27 +1,57 @@
 # https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
 name: "rxiv Feed Action"
-description: "Log a weekly CSV feed of papers submitted to biorxiv.org or medrxiv.org for selected categories."
+description: "Log a weekly CSV feed of papers from arXiv, bioRxiv, or medRxiv for selected categories."
 author: "qte77"
 branding:
   icon: "file-text"
   color: "green"
 inputs:
   OUT_DIR:
-    description: "Directory to write CSV output files."
-    default: "./data"
+    description: >-
+      Directory to write CSV output files. Convention: ./data/<server>
+      (e.g. ./data/arxiv) so multiple servers coexist without colliding.
+    default: "./data/arxiv"
+  SERVER:
+    description: "API server: arxiv, biorxiv, or medrxiv."
+    default: "arxiv"
+  TOPICS:
+    description: >-
+      arXiv search_query (URL-encoded, OR-joined). Used when SERVER=arxiv.
+      Example: 'cat:cs.CV+OR+cat:cs.LG'.
+    default: "cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO"
+  INCLUDE_CITATIONS:
+    description: >-
+      Enrich arXiv rows with Semantic Scholar citation counts (true/false).
+      Adds Citations/References/InfluentialCitations columns. arXiv only.
+    default: "false"
+  SEMANTIC_SCHOLAR_API_KEY:
+    description: "Optional Semantic Scholar API key for higher rate limits."
+    default: ""
+  MAX_AGE_DAYS:
+    description: "arXiv only: skip papers published more than N days ago."
+    default: "7"
+  DATE_FROM:
+    description: "arXiv only: YYYY-MM-DD lower bound on submittedDate. Empty = use MAX_AGE_DAYS."
+    default: ""
+  DATE_TO:
+    description: "arXiv only: YYYY-MM-DD upper bound on submittedDate. Empty = today."
+    default: ""
+  PAGE_SIZE:
+    description: "arXiv only: results per pagination page."
+    default: "1000"
+  MAX_PAGES:
+    description: "arXiv only: cap on pagination pages per run."
+    default: "5"
   DAYS:
-    description: "Number of days back to fetch."
+    description: "bioRxiv/medRxiv only: number of days back to fetch."
     default: "1"
   CATEGORIES:
     description: >-
-      Comma-separated bioRxiv categories to keep (case-insensitive). Empty
-      keeps all. Filtering is applied client-side after fetching the full
-      date range, since the bioRxiv /details/ API has no server-side
-      category filter.
+      bioRxiv/medRxiv only: comma-separated categories to keep
+      (case-insensitive). Empty keeps all. Filtering is applied
+      client-side; the bioRxiv /details/ API has no server-side category
+      filter.
     default: ""
-  SERVER:
-    description: "API server: biorxiv or medrxiv."
-    default: "biorxiv"
   TOKEN:
     description: "GitHub token for pushing changes."
     default: ""
@@ -41,14 +71,22 @@ runs:
       with:
         enable-cache: true
 
-    - name: Fetch and write bioRxiv stats
+    - name: Fetch and write rxiv stats
       shell: bash
       env:
         OUT_DIR: ${{ inputs.OUT_DIR }}
+        SERVER: ${{ inputs.SERVER }}
+        TOPICS: ${{ inputs.TOPICS }}
+        INCLUDE_CITATIONS: ${{ inputs.INCLUDE_CITATIONS }}
+        SEMANTIC_SCHOLAR_API_KEY: ${{ inputs.SEMANTIC_SCHOLAR_API_KEY }}
+        MAX_AGE_DAYS: ${{ inputs.MAX_AGE_DAYS }}
+        DATE_FROM: ${{ inputs.DATE_FROM }}
+        DATE_TO: ${{ inputs.DATE_TO }}
+        PAGE_SIZE: ${{ inputs.PAGE_SIZE }}
+        MAX_PAGES: ${{ inputs.MAX_PAGES }}
         DAYS: ${{ inputs.DAYS }}
         CATEGORIES: ${{ inputs.CATEGORIES }}
-        SERVER: ${{ inputs.SERVER }}
-        PYTHONPATH: ${{ github.action_path }}/src
+        PYTHONPATH: ${{ github.action_path }}
         UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/.venv
       run: |
         uv sync --frozen --no-dev --project "${{ github.action_path }}"

--- a/docs/categories.md
+++ b/docs/categories.md
@@ -1,13 +1,49 @@
 # Server categories
 
 Reference list of subject categories per preprint server. Used to choose
-sensible defaults for the `CATEGORIES` action input.
+sensible defaults for the `TOPICS` (arXiv) or `CATEGORIES` (bioRxiv,
+medRxiv) action input.
 
 Status legend:
 
 - **canonical** — full list, verified
 - **sampled** — partial; needs full pagination from a longer-lived runner
 - **unreachable** — blocked from CI sandbox; re-run elsewhere
+
+## arXiv (canonical)
+
+Source: <https://arxiv.org/category_taxonomy> — query via
+`https://export.arxiv.org/api/query?search_query=cat:<group>.<subject>`.
+
+Top-level groups (each has many subjects):
+
+```text
+astro-ph    Astrophysics
+cond-mat    Condensed Matter
+cs          Computer Science
+econ        Economics
+eess        Electrical Engineering and Systems Science
+gr-qc       General Relativity and Quantum Cosmology
+hep-ex      High Energy Physics - Experiment
+hep-lat     High Energy Physics - Lattice
+hep-ph      High Energy Physics - Phenomenology
+hep-th      High Energy Physics - Theory
+math        Mathematics
+math-ph     Mathematical Physics
+nlin        Nonlinear Sciences
+nucl-ex     Nuclear Experiment
+nucl-th     Nuclear Theory
+physics     Physics
+q-bio       Quantitative Biology
+q-fin       Quantitative Finance
+quant-ph    Quantum Physics
+stat        Statistics
+```
+
+The action's default `TOPICS` covers six CS subjects — `cat:cs.CV`,
+`cat:cs.LG`, `cat:cs.CL`, `cat:cs.AI`, `cat:cs.NE`, `cat:cs.RO` —
+joined with `+OR+`. Tailor `TOPICS` for other domains, e.g.
+`cat:q-bio.PE+OR+cat:q-bio.QM` for quantitative biology.
 
 ## bioRxiv (canonical, 25)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gha-rxiv-stats-action"
-version = "0.1.0"
+version = "0.2.0"
 description = "Log daily stats of papers submitted to biorxiv.org"
 authors = [
     {name = "qte77", email = "qte@77.gh"}
@@ -30,7 +30,7 @@ max-complexity = 10
 "tests/**" = ["S101"]
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = false

--- a/src/app.py
+++ b/src/app.py
@@ -1,66 +1,194 @@
-"""Main entry point for bioRxiv / medRxiv stats action."""
+"""Main entry point for the rxiv-feed action.
+
+Dispatches by ``SERVER`` env var to a per-server fetcher. arxiv is the
+default. All side-effects (env reads, filesystem, network) live inside
+``main()`` or the ``_run_*`` helpers — never at module level — so
+``import src.app`` is cheap and test-safe.
+"""
 
 import json
 from os import getenv
 
-from fetchers.biorxiv import (
+from src.fetchers.arxiv import build_date_query, get_parsed_output, get_total_results
+from src.fetchers.arxiv_citations import enrich_row, get_citations
+from src.fetchers.biorxiv import (
     build_date_range,
     needs_pagination,
     parse_biorxiv_json,
     prune_existing_csvs,
 )
-from fetchers.common import (
+from src.fetchers.common import (
     filter_new_rows,
     get_api_response,
     load_all_existing_ids,
     write_file,
 )
+from src.validation import validate_env
 
-OUT_DIR = getenv("OUT_DIR", "./data")
-DAYS = int(getenv("DAYS", "1"))
-CATEGORIES = {c.strip() for c in getenv("CATEGORIES", "").split(",") if c.strip()}
-SERVER = getenv("SERVER", "biorxiv")  # biorxiv or medrxiv
-
-HEADER = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"]
-PAGE_SIZE = 100
-BASE_URL = f"https://api.biorxiv.org/details/{SERVER}"
-
-pruned = prune_existing_csvs(OUT_DIR, CATEGORIES)
-if pruned:
-    print(f"Pruned {pruned} rows outside CATEGORIES from {OUT_DIR}")
-
-existing_ids = load_all_existing_ids(OUT_DIR)
-print(f"Loaded {len(existing_ids)} existing paper IDs from {OUT_DIR}")
+_BIORXIV_HEADER = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"]
+_ARXIV_HEADER = ["Published", "ISOWeek", "Updated", "ID", "Version", "Title", "Categories"]
+_ARXIV_CITATIONS_HEADER = ["Citations", "References", "InfluentialCitations"]
 
 
-def main() -> None:
-    """Fetch, parse, and write bioRxiv stats as weekly CSV files."""
-    start_date, end_date = build_date_range(DAYS)
+def _run_biorxiv(server: str, out_dir: str, days: int, categories: set) -> None:
+    """Fetch bioRxiv / medRxiv weekly stats and write per-week CSVs."""
+    pruned = prune_existing_csvs(out_dir, categories)
+    if pruned:
+        print(f"Pruned {pruned} rows outside CATEGORIES from {out_dir}")
+    existing_ids = load_all_existing_ids(out_dir)
+    print(f"Loaded {len(existing_ids)} existing paper IDs from {out_dir}")
+
+    base_url = f"https://api.biorxiv.org/details/{server}"
+    page_size = 100
+    start_date, end_date = build_date_range(days)
     cursor = 0
     all_weeks: dict = {}
 
     while True:
-        url = f"{BASE_URL}/{start_date}/{end_date}/{cursor}/json"
-
+        url = f"{base_url}/{start_date}/{end_date}/{cursor}/json"
         data = get_api_response(url)
         payload = json.loads(data)
-        messages = payload.get("messages", [])
-
-        weekly = parse_biorxiv_json(data, CATEGORIES)
+        weekly = parse_biorxiv_json(data, categories)
         for week, rows in weekly.items():
             all_weeks.setdefault(week, []).extend(rows)
-
-        if not needs_pagination(messages):
+        if not needs_pagination(payload.get("messages", [])):
             break
-        cursor += PAGE_SIZE
+        cursor += page_size
 
     for (year, week), rows in all_weeks.items():
         new_rows = filter_new_rows(rows, existing_ids)
         if new_rows:
-            year_dir = f"{OUT_DIR}/{year}"
-            write_file(new_rows, str(week), year_dir, HEADER)
+            year_dir = f"{out_dir}/{year}"
+            write_file(new_rows, str(week), year_dir, _BIORXIV_HEADER)
             existing_ids.update((row[2], str(row[3])) for row in new_rows)
             print(f"Wrote {year}/week {week}: {len(new_rows)} new papers")
+
+
+def _arxiv_paginate(  # noqa: PLR0913 - paginator config requires many parameters
+    base_url: str,
+    search_query: str,
+    page_size: int,
+    max_pages: int,
+    allowed: set,
+    effective_max_age: int | None,
+) -> dict:
+    """Paginate arXiv API, return weekly dict of parsed rows."""
+    probe_url = f"{base_url}search_query={search_query}&start=0&max_results=1&sortBy=submittedDate"
+    total = get_total_results(get_api_response(probe_url))
+    fetch_limit = min(total, max_pages * page_size)
+    print(f"arXiv reports {total} total results. Fetching up to {fetch_limit}.")
+
+    out: dict = {}
+    start = 0
+    while start < fetch_limit:
+        page_url = (
+            f"{base_url}search_query={search_query}"
+            f"&start={start}&max_results={page_size}&sortBy=submittedDate"
+        )
+        try:
+            page = get_api_response(page_url)
+        except RuntimeError as e:
+            print(f"API error at start={start}, stopping: {e}")
+            break
+        weekly = get_parsed_output(page, allowed_categories=allowed, max_age_days=effective_max_age)
+        if not weekly:
+            print(f"No matching papers on page starting at {start}. Stopping.")
+            break
+        for key, rows in weekly.items():
+            out.setdefault(key, []).extend(rows)
+        start += page_size
+    return out
+
+
+def _run_arxiv(  # noqa: PLR0913 - aggregates many env-driven knobs
+    out_dir: str,
+    topics: str,
+    include_citations: bool,
+    max_age_days: int,
+    date_from: str,
+    date_to: str,
+    page_size: int,
+    max_pages: int,
+) -> None:
+    """Fetch arXiv stats by topic, optionally enrich with citation counts."""
+    import re
+
+    allowed = set(re.findall(r"cat:([a-zA-Z\-]+\.[A-Z]+)", topics))
+    print(f"Allowed categories: {sorted(allowed)}")
+
+    date_query = build_date_query(date_from=date_from or None, date_to=date_to or None)
+    effective_max_age = None if date_query else max_age_days
+    search_query = f"{topics}{date_query}"
+
+    existing_ids = load_all_existing_ids(out_dir, dedup_cols=(3, 4))
+    print(f"Loaded {len(existing_ids)} existing paper IDs from {out_dir}")
+
+    base_url = "https://export.arxiv.org/api/query?"
+    header = _ARXIV_HEADER + (_ARXIV_CITATIONS_HEADER if include_citations else [])
+
+    all_weeks = _arxiv_paginate(
+        base_url, search_query, page_size, max_pages, allowed, effective_max_age
+    )
+
+    total_new = 0
+    for (year, week), rows in all_weeks.items():
+        new_rows = filter_new_rows(rows, existing_ids, dedup_cols=(3, 4))
+        if not new_rows:
+            continue
+        if include_citations:
+            new_rows = [enrich_row(row, get_citations(row[3])) for row in new_rows]
+        year_dir = f"{out_dir}/{year}"
+        write_file(new_rows, str(week), year_dir, header, dedup_cols=(3, 4))
+        existing_ids.update((row[3], str(row[4])) for row in new_rows)
+        total_new += len(new_rows)
+        print(f"Wrote {year}/week {week}: {len(new_rows)} new papers")
+    print(f"Done. {total_new} new papers written.")
+
+
+_ENV_KEYS = (
+    "OUT_DIR",
+    "SERVER",
+    "DAYS",
+    "CATEGORIES",
+    "TOPICS",
+    "INCLUDE_CITATIONS",
+    "MAX_AGE_DAYS",
+    "DATE_FROM",
+    "DATE_TO",
+    "PAGE_SIZE",
+    "MAX_PAGES",
+)
+
+
+def main() -> None:
+    """Read env, validate, dispatch to the per-server runner."""
+    # Only include set vars in the env dict. validate_env treats absence as
+    # "use the default"; empty strings as malformed.
+    env = {k: v for k in _ENV_KEYS if (v := getenv(k)) is not None}
+    validate_env(env)
+
+    server = env.get("SERVER") or "arxiv"
+    out_dir = env.get("OUT_DIR") or "./data/arxiv"
+
+    if server == "arxiv":
+        _run_arxiv(
+            out_dir=out_dir,
+            topics=env.get("TOPICS")
+            or "cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO",
+            include_citations=env.get("INCLUDE_CITATIONS", "false").lower() == "true",
+            max_age_days=int(env.get("MAX_AGE_DAYS") or "7"),
+            date_from=env.get("DATE_FROM", ""),
+            date_to=env.get("DATE_TO", ""),
+            page_size=int(env.get("PAGE_SIZE") or "1000"),
+            max_pages=int(env.get("MAX_PAGES") or "5"),
+        )
+    else:
+        _run_biorxiv(
+            server=server,
+            out_dir=out_dir,
+            days=int(env.get("DAYS") or "1"),
+            categories={c.strip() for c in env.get("CATEGORIES", "").split(",") if c.strip()},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,54 @@
+"""Dispatch tests for src/app.py.
+
+Tests `main()` only — the per-server logic is covered by fetcher tests.
+Patches `_run_arxiv` / `_run_biorxiv` so the test never touches HTTP.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.app import main
+
+
+def test_main_dispatches_to_arxiv(monkeypatch):
+    """SERVER=arxiv routes to _run_arxiv only."""
+    monkeypatch.setenv("SERVER", "arxiv")
+    monkeypatch.setenv("TOPICS", "cat:cs.AI")
+    monkeypatch.setenv("OUT_DIR", "./data/arxiv-test")
+
+    with (
+        patch("src.app._run_arxiv", create=True) as mock_arxiv,
+        patch("src.app._run_biorxiv", create=True) as mock_bio,
+    ):
+        main()
+
+    mock_arxiv.assert_called_once()
+    mock_bio.assert_not_called()
+
+
+def test_main_dispatches_to_biorxiv(monkeypatch):
+    """SERVER=biorxiv routes to _run_biorxiv only."""
+    monkeypatch.setenv("SERVER", "biorxiv")
+    monkeypatch.setenv("OUT_DIR", "./data/biorxiv-test")
+
+    with (
+        patch("src.app._run_arxiv", create=True) as mock_arxiv,
+        patch("src.app._run_biorxiv", create=True) as mock_bio,
+    ):
+        main()
+
+    mock_bio.assert_called_once()
+    mock_arxiv.assert_not_called()
+
+
+def test_main_raises_on_invalid_env(monkeypatch):
+    """validate_env is called inside main; bad SERVER raises ValueError."""
+    monkeypatch.setenv("SERVER", "chemrxiv")
+
+    with (
+        patch("src.app._run_arxiv", create=True),
+        patch("src.app._run_biorxiv", create=True),
+    ):
+        with pytest.raises(ValueError, match="SERVER"):
+            main()

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ wheels = [
 
 [[package]]
 name = "gha-rxiv-stats-action"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
Stacked on #90. Merge order: #87 → #88 → #89 → #90 → this PR. Each auto-retargets to \`main\` as its base lands.

## ⚠️ Breaking change

**\`SERVER\` default flips from \`biorxiv\` to \`arxiv\`** (and \`OUT_DIR\` default from \`./data\` to \`./data/arxiv\`). Any external consumer of this action that does NOT explicitly set \`SERVER\` will silently switch from bioRxiv to arXiv. The in-repo cron matrix sets \`SERVER\` explicitly, so its behaviour is unchanged.

Pin \`@v0.1.0\` to keep the bioRxiv default; this PR releases as \`0.2.0\` (minor-version bump per SemVer-for-breaking-defaults).

## Summary
Fourth PR in the #72 sequence. The first one with user-facing behaviour: arxiv becomes a first-class fetcher and the default server.

- **\`src/app.py\` rewrite**: module-level imports only; \`main()\` reads env → \`validate_env\` → dispatches to \`_run_biorxiv\` or \`_run_arxiv\`. arxiv runner ported from \`gha-arxiv-stats-action/src/app.py\` (no module-level network call). Imports use \`src.fetchers.*\` / \`src.validation\` so the same paths resolve in pytest and at runtime.
- **\`action.yaml\`**: flips \`SERVER\` and \`OUT_DIR\` defaults. Adds 8 new inputs — \`TOPICS\`, \`INCLUDE_CITATIONS\`, \`SEMANTIC_SCHOLAR_API_KEY\`, \`MAX_AGE_DAYS\`, \`DATE_FROM\`, \`DATE_TO\`, \`PAGE_SIZE\`, \`MAX_PAGES\`. Adjusts \`PYTHONPATH\` to point at the action root (not \`/src\`) so \`from src.* import ...\` works at runtime.
- **\`README.md\`**: arxiv-first rewrite. Default usage example needs only \`TOKEN\`. arxiv-with-citations example added; bioRxiv/medRxiv moved into dedicated subsections.
- **\`docs/categories.md\`**: new \`## arXiv (canonical)\` section at the top with the 20 top-level taxonomy groups and the \`TOPICS\` default rationale.
- **\`pyproject.toml\`**: version \`0.1.0\` → \`0.2.0\`; \`tool.bumpversion.current_version\` matches.
- **\`CHANGELOG.md\`**: \`[Unreleased]\` (B1, B1.5, B2, B3, B4 entries) cut into \`[0.2.0] - 2026-05-15\` release section with explicit breaking-change advisory.

## Test plan
- [x] \`uv run ruff check .\` — 0 violations under strict ruleset
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pytest -v\` — **68 passed** (65 from B3 + 3 dispatch)
- [ ] CI Lint, Tests, Lint MD and Links, CodeQL all green

## Dispatch tests
\`tests/test_app.py\` covers:
- \`SERVER=arxiv\` routes to \`_run_arxiv\` only
- \`SERVER=biorxiv\` routes to \`_run_biorxiv\` only
- \`SERVER=chemrxiv\` (or other invalid) raises \`ValueError\` from \`validate_env\`

Helpers are patched (no HTTP, no filesystem) — per-server logic is covered by the fetcher tests in B2/B3.

## Commits
- \`2569060\` — \`test: add app dispatch tests (RED)\` (collection ImportError; src/app.py imports without \`src.\` prefix don't resolve in pytest)
- \`297d598\` — \`feat(action): wire arxiv dispatch + flip defaults to arxiv (#72)\` (src/app.py rewrite + action.yaml + README + categories + version 0.1.0→0.2.0 + CHANGELOG cut)

## What's left for B5
- Migrate the 16 historical arxiv CSVs into \`data/arxiv/\`
- Add the arxiv row to \`.github/workflows/update-rxiv-feed.yaml\` matrix
- Open the deprecation PR on \`qte77/gha-arxiv-stats-action\`

Generated with Claude <noreply@anthropic.com>