### PR TITLE
chore(docs): update references for gha-arxiv-stats-action-legacy archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Historical arxiv data migrated from `qte77/gha-arxiv-stats-action`
-  under `data/arxiv/`: 6 files in `2024/` (legacy 6-column schema:
+  (renamed to `gha-arxiv-stats-action-legacy` and archived after the
+  fold-in) under `data/arxiv/`: 6 files in `2024/` (legacy 6-column schema:
   `Published,Weekday,Updated,ID,Version,Title`) and 10 files in
   `2026/` (current 7-column schema with `Categories`). Schema drift is
   harmless — the dedup key `(ID, Version)` is at the same indices

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ The action appends new rows on each run and dedupes by
 `(DOI, Version)` for bioRxiv/medRxiv or `(ID, Version)` for arXiv.
 
 `data/arxiv/` is pre-populated with 16 historical weekly CSVs migrated
-from [`qte77/gha-arxiv-stats-action`](https://github.com/qte77/gha-arxiv-stats-action)
-when the action was folded in (issue #72). The 6 files under
+from [`qte77/gha-arxiv-stats-action-legacy`](https://github.com/qte77/gha-arxiv-stats-action-legacy)
+(formerly `gha-arxiv-stats-action`; archived after the fold-in) when
+this action absorbed its scope (issue #72). The 6 files under
 `data/arxiv/2024/` use a legacy 6-column schema
 (`Published,Weekday,Updated,ID,Version,Title`); files from 2026 onward
 use the current 7-column schema with a trailing `Categories` column.

--- a/src/validation.py
+++ b/src/validation.py
@@ -1,6 +1,6 @@
 """Env-var validation for the rxiv-feed action.
 
-Adapted from ``qte77/gha-arxiv-stats-action/src/validation.py``. Validates
+Adapted from ``qte77/gha-arxiv-stats-action-legacy/src/validation.py``. Validates
 env vars that are actually consumed by ``src/app.py`` and per-server
 fetchers — not the stale ``START_RESULT``/``RESULT_COUNT``/
 ``MAX_RESULTS_PER_QUERY`` triple from the original which is unused.


### PR DESCRIPTION
The standalone arxiv action (formerly \`qte77/gha-arxiv-stats-action\`) was renamed to \`qte77/gha-arxiv-stats-action-legacy\` and archived after this repo absorbed its scope in v0.2.0 (#72).

## Updates
- **\`README.md\`** Data section — link points at the new legacy name with a note explaining the rename and archive.
- **\`CHANGELOG.md\`** \`[Unreleased]\` — clarifies the rename / archive context for the just-shipped data migration entry.
- **\`src/validation.py\`** — docstring source-attribution updated.

## What's intentionally NOT changed
Historical entries in the \`[0.2.0]\` release section keep the original \`gha-arxiv-stats-action\` name. Release notes are immutable; GitHub's repo-rename redirect handles old URLs transparently.

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run pytest -v\` — 68 passed
- [ ] CI green