### PR TITLE
chore: align package name with repo + refresh description; trim lychee exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gha-rxiv-stats-action
+# gha-rxiv-feed-action
 
 Logs a weekly CSV feed of papers submitted to [arXiv](https://arxiv.org/),
 [bioRxiv](https://www.biorxiv.org/), and [medRxiv](https://www.medrxiv.org/)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,8 +1,2 @@
-# Local lychee config: extends qte77/.github canonical with project-specific URL excludes.
+# Local lychee config: extends qte77/.github canonical with project-specific tuning.
 accept = [200, 202, 204, 301, 401, 403, 429]
-
-# Workflow badge URLs 404 on PR branches before the workflow exists on the
-# default branch (chicken-and-egg). Once the PR merges, the badge resolves.
-exclude = [
-  "^https://github\\.com/qte77/gha-rxiv-feed-action/actions/workflows/.+/badge\\.svg$",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "gha-rxiv-stats-action"
+name = "gha-rxiv-feed-action"
 version = "0.2.0"
-description = "Log daily stats of papers submitted to biorxiv.org"
+description = "Log a weekly CSV feed of papers submitted to arXiv, bioRxiv, or medRxiv for selected categories."
 authors = [
     {name = "qte77", email = "qte@77.gh"}
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 ]
 
 [[package]]
-name = "gha-rxiv-stats-action"
+name = "gha-rxiv-feed-action"
 version = "0.2.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
Three small post-v0.2.0 cleanups.

## Changes

- **\`pyproject.toml\`**: package renamed \`gha-rxiv-stats-action\` → \`gha-rxiv-feed-action\` to match the GitHub repo name. Description updated from the stale \"biorxiv.org\" tagline to the multi-server scope. \`uv.lock\` regenerated.
- **\`README.md\`**: H1 updated to match the new package name.
- **\`lychee.toml\`**: removed the workflow-badge URL exclude pattern. The chicken-and-egg justification (badges 404 on PR branches before the workflow exists on the default branch) no longer applies — all workflows have been on \`main\` since long before v0.2.0. Trivial to restore if a future PR adds a brand-new workflow file.

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run pytest -v\` — 68 passed
- [ ] CI green (especially \`lint / links\` — confirms the exclude wasn't load-bearing)