### PR TITLE
fix(arxiv): handle transient probe failure gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- arxiv probe call in `_arxiv_paginate` no longer crashes the job when
+  `export.arxiv.org` is transiently unavailable. The probe now matches
+  the per-page error-handling pattern: log and early-exit with an empty
+  result so the matrix job completes and the next scheduled run
+  self-heals. Triggered by run #26009245522.
+
 ### Added
 
 - Historical arxiv data migrated from `qte77/gha-arxiv-stats-action`

--- a/src/app.py
+++ b/src/app.py
@@ -74,7 +74,11 @@ def _arxiv_paginate(  # noqa: PLR0913 - paginator config requires many parameter
 ) -> dict:
     """Paginate arXiv API, return weekly dict of parsed rows."""
     probe_url = f"{base_url}search_query={search_query}&start=0&max_results=1&sortBy=submittedDate"
-    total = get_total_results(get_api_response(probe_url))
+    try:
+        total = get_total_results(get_api_response(probe_url))
+    except RuntimeError as e:
+        print(f"arXiv probe failed, skipping run: {e}")
+        return {}
     fetch_limit = min(total, max_pages * page_size)
     print(f"arXiv reports {total} total results. Fetching up to {fetch_limit}.")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,3 +52,20 @@ def test_main_raises_on_invalid_env(monkeypatch):
     ):
         with pytest.raises(ValueError, match="SERVER"):
             main()
+
+
+def test_arxiv_paginate_returns_empty_on_probe_failure():
+    """Probe failure must not crash the run; returns {} so caller no-ops."""
+    from src.app import _arxiv_paginate
+
+    with patch("src.app.get_api_response", side_effect=RuntimeError("boom")):
+        result = _arxiv_paginate(
+            base_url="https://export.arxiv.org/api/query?",
+            search_query="cat:cs.AI",
+            page_size=100,
+            max_pages=5,
+            allowed={"cs.AI"},
+            effective_max_age=7,
+        )
+
+    assert result == {}


### PR DESCRIPTION
## Summary

The scheduled `Update rxiv feed` run [#26009245522](https://github.com/qte77/gha-rxiv-feed-action/actions/runs/26009245522) failed on the **arxiv** matrix job while biorxiv/medrxiv succeeded. Root cause: a transient `export.arxiv.org` outage exhausted the 3-retry budget in `get_api_response`, which raised `RuntimeError`. The per-page pagination loop already catches that exception and breaks gracefully (`src/app.py:88-92`), but the **probe call at `src/app.py:77` was bare**, so the same exception propagated and crashed the job.

This PR wraps the probe call in `try/except RuntimeError` to mirror the per-page pattern: log the failure, early-exit with `{}`, let the next scheduled run self-heal.

## Commits (strict TDD, by topic)

1. `e1f981c test(arxiv): add regression for transient probe failure` — RED. Locks the behavior; fails on `main` as expected.
2. `4009fa1 fix(arxiv): handle transient probe failure gracefully` — GREEN. Wrap + CHANGELOG entry.

## Test plan

- [x] New test `test_arxiv_paginate_returns_empty_on_probe_failure` passes
- [x] All 69 existing tests still pass (`uv run pytest -q`)
- [x] `uv run ruff check src/ tests/` clean (S, C90, E, F, I, W)
- [ ] CI: `Lint`, `Tests`, `CodeQL`, `Lint MD and Links` green
- [ ] Post-merge smoke: manually trigger `Update rxiv feed` workflow and confirm arxiv job no longer exits 1 on a probe failure

## Out of scope

- GHA `::warning::` annotations for skipped runs — separate issue if monitoring demand emerges
- Retry/backoff tuning — root cause is intermittent upstream, not retry budget