### PR TITLE
chore: pin composite action deps to full-length SHAs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,13 +59,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
         token: ${{ inputs.TOKEN || github.token }}
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:


### PR DESCRIPTION
## Summary
Pin the two action refs inside the composite action `action.yaml` to full-length commit SHAs, completing the SHA-pinning effort from #6/#74 (which only touched workflow files).

- `actions/checkout@v6` → `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` (same SHA the workflow files already use)
- `astral-sh/setup-uv@v7` → `astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0`

## Why
1. **Consistency** — workflow files in this repo are already SHA-pinned (commit 5b39aa9). `action.yaml` is the composite action consumed by users of this marketplace action and should follow the same policy.
2. **Defense-in-depth** — tag refs are mutable. SHA pinning hardens against upstream tag-rewrite / supply-chain attacks regardless of org-level enforcement.
3. **Fork enforcement** — surfaced by a downstream consumer (Lambda-Biolab/gha-rxiv-feed-action) whose repo enforces `sha_pinning_required: true`; the unpinned refs caused `Update rxiv feed` runs to fail with "actions ... are not allowed because all actions must be pinned to a full-length commit SHA."

## Test plan
- [ ] CI green (Lint, Tests, CodeQL, Lint MD).
- [ ] After merge, downstream fork rebases and re-runs `Update rxiv feed` — confirms the policy block is gone.

Generated with Claude <noreply@anthropic.com>