### PR TITLE
chore: pin action deps, bump codeql-action v4.35.5, release v0.2.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+      uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.1] - 2026-05-24
+
+### Changed
+
+- Composite action `action.yaml` steps pinned to full-length commit SHAs
+  to match the workflow-files policy (consistency with #74 and
+  defense-in-depth against upstream tag rewrites). Surfaced by a
+  downstream consumer (Lambda-Biolab fork) whose repo enforces
+  `sha_pinning_required: true`. Supersedes #112.
+- `github/codeql-action/{init,autobuild,analyze}` bumped 4.35.4 →
+  4.35.5 (SHA `9e0d7b8`). Supersedes #108.
+
 ### Fixed
 
 - arxiv probe call in `_arxiv_paginate` no longer crashes the job when

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Logs a weekly CSV feed of papers submitted to [arXiv](https://arxiv.org/),
 [bioRxiv](https://www.biorxiv.org/), and [medRxiv](https://www.medrxiv.org/)
 for selected categories. Cron cadence is set by the calling workflow.
 
-![Version](https://img.shields.io/badge/version-0.2.0-8A2BE2)
+![Version](https://img.shields.io/badge/version-0.2.1-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Update rxiv feed](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/update-rxiv-feed.yaml/badge.svg)](https://github.com/qte77/gha-rxiv-feed-action/actions/workflows/update-rxiv-feed.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-rxiv-feed-action/badge)](https://www.codefactor.io/repository/github/qte77/gha-rxiv-feed-action)

--- a/action.yaml
+++ b/action.yaml
@@ -59,13 +59,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
         token: ${{ inputs.TOKEN || github.token }}
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gha-rxiv-feed-action"
-version = "0.2.0"
+version = "0.2.1"
 description = "Log a weekly CSV feed of papers submitted to arXiv, bioRxiv, or medRxiv for selected categories."
 authors = [
     {name = "qte77", email = "qte@77.gh"}
@@ -30,7 +30,7 @@ max-complexity = 10
 "tests/**" = ["S101"]
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = false


### PR DESCRIPTION
## Summary

Bundles the two open CI/infra PRs and rolls a patch release.

- **Pin composite action deps to SHAs** (`action.yaml`) — completes #74 in the composite action consumed downstream. Surfaced by Lambda-Biolab fork enforcing `sha_pinning_required: true`. Supersedes #112.
  - `actions/checkout@v6` → `de0fac2…` (v6.0.2)
  - `astral-sh/setup-uv@v7` → `37802ad…` (v7.6.0)
- **Bump codeql-action 4.35.4 → 4.35.5** (`.github/workflows/codeql.yml`) — Dependabot patch. Supersedes #108.
- **Release v0.2.1** — bumped locally (not via the `Bump and Release` workflow). `pyproject.toml`, README badge, `CHANGELOG.md` rotated. Tag/release will be cut manually after merge.

## Why

The two open PRs touched disjoint files and were both small CI hygiene fixes; squashing avoids serial Dependabot rebases and gives one merge point. `[Unreleased]` already contained the post-#72 data fold-in and the arxiv probe fix (#101) — bundling them under `v0.2.1` ships that work.

## Test plan

- [ ] Lint (Ruff) green
- [ ] Tests green
- [ ] CodeQL green (validates the 4.35.5 bump)
- [ ] Lint MD and Links green
- [ ] After merge: downstream Lambda-Biolab fork rebases — confirms `sha_pinning_required` no longer blocks `Update rxiv feed`.

Closes #112
Closes #108

Generated with Claude <noreply@anthropic.com>