### PR TITLE
docs: drop floating v0 tag, pin README examples to @v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Floating major-version tag `v0` removed.** Consumers must pin a
+  specific tag (`@v0.2.1`) or commit SHA. Aligns with the SHA-pinning
+  posture (no mutable refs in `uses:`). README usage examples updated
+  to `@v0.2.1`.
 - Composite action `action.yaml` steps pinned to full-length commit SHAs
   to match the workflow-files policy (consistency with #74 and
   defense-in-depth against upstream tag rewrites). Surfaced by a

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for selected categories. Cron cadence is set by the calling workflow.
 Default: fetch the last week of arXiv submissions in CS/AI categories.
 
 ```yaml
-- uses: qte77/gha-rxiv-feed-action@v0
+- uses: qte77/gha-rxiv-feed-action@v0.2.1
   with:
     TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -34,7 +34,7 @@ Default: fetch the last week of arXiv submissions in CS/AI categories.
 ### arXiv with custom topics + citation enrichment
 
 ```yaml
-- uses: qte77/gha-rxiv-feed-action@v0
+- uses: qte77/gha-rxiv-feed-action@v0.2.1
   with:
     TOPICS: "cat:cs.CV+OR+cat:cs.LG"
     INCLUDE_CITATIONS: "true"
@@ -45,7 +45,7 @@ Default: fetch the last week of arXiv submissions in CS/AI categories.
 ### bioRxiv / medRxiv
 
 ```yaml
-- uses: qte77/gha-rxiv-feed-action@v0
+- uses: qte77/gha-rxiv-feed-action@v0.2.1
   with:
     SERVER: "biorxiv"
     OUT_DIR: "./data/biorxiv"
@@ -67,7 +67,7 @@ strategy:
       - server: medrxiv
         categories: "infectious diseases,genetic and genomic medicine"
 steps:
-  - uses: qte77/gha-rxiv-feed-action@v0
+  - uses: qte77/gha-rxiv-feed-action@v0.2.1
     with:
       OUT_DIR: "./data/${{ matrix.server }}"
       SERVER: ${{ matrix.server }}


### PR DESCRIPTION
## Summary

Follow-up to #113 (v0.2.1). Aligns README usage examples and the v0.2.1 CHANGELOG with the SHA-pinning posture: no mutable refs in \`uses:\`.

- README: 4× \`qte77/gha-rxiv-feed-action@v0\` → \`@v0.2.1\`.
- CHANGELOG \`[0.2.1]\` \`### Changed\`: note the \`v0\` floating-tag removal as a user-visible policy change.

## Why

The \`v0.2.1\` release pins all action.yaml deps to full-length commit SHAs (PR #113). Keeping a mutable \`v0\` major-version tag would undermine that — consumers pinning \`@v0\` get tag-rewrite exposure for the *outer* action ref, same supply-chain concern that motivated #112. Dropping \`v0\` forces explicit pinning (\`@v0.2.1\` or full SHA). The tradeoff is no auto-patch upgrades for casual consumers; \`uses:\` has no \`@latest\` ref equivalent.

## Test plan

- [ ] Lint MD and Links green (only doc files changed; CI scope is small)
- [ ] After merge: \`v0\` deleted from remote, \`v0.2.1\` tag points at the post-merge HEAD, GitHub release cut.

Generated with Claude <noreply@anthropic.com>