### PR TITLE
feat(schema): include abstract column (and authors for arXiv)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -25,12 +25,17 @@ from src.fetchers.common import (
 )
 from src.validation import validate_env
 
-_BIORXIV_HEADER = [
-    "Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors", "Abstract",
-]
+_BIORXIV_HEADER = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors", "Abstract"]
 _ARXIV_HEADER = [
-    "Published", "ISOWeek", "Updated", "ID", "Version", "Title", "Categories",
-    "Authors", "Abstract",
+    "Published",
+    "ISOWeek",
+    "Updated",
+    "ID",
+    "Version",
+    "Title",
+    "Categories",
+    "Authors",
+    "Abstract",
 ]
 _ARXIV_CITATIONS_HEADER = ["Citations", "References", "InfluentialCitations"]
 

--- a/src/app.py
+++ b/src/app.py
@@ -25,8 +25,13 @@ from src.fetchers.common import (
 )
 from src.validation import validate_env
 
-_BIORXIV_HEADER = ["Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors"]
-_ARXIV_HEADER = ["Published", "ISOWeek", "Updated", "ID", "Version", "Title", "Categories"]
+_BIORXIV_HEADER = [
+    "Date", "ISOWeek", "DOI", "Version", "Category", "Title", "Authors", "Abstract",
+]
+_ARXIV_HEADER = [
+    "Published", "ISOWeek", "Updated", "ID", "Version", "Title", "Categories",
+    "Authors", "Abstract",
+]
 _ARXIV_CITATIONS_HEADER = ["Citations", "References", "InfluentialCitations"]
 
 

--- a/src/fetchers/arxiv.py
+++ b/src/fetchers/arxiv.py
@@ -114,8 +114,16 @@ def get_parsed_output(
             title = title.translate({ord(s): None})
         title = f"'{title}'"
 
-        authors = extract_authors(j.get("authors"))
-        abstract = str(j.get("summary", "")).translate({ord("\n"): " ", ord("\r"): " "})
+        try:
+            raw_authors = j["authors"]
+        except (KeyError, TypeError):
+            raw_authors = None
+        authors = extract_authors(raw_authors)
+        try:
+            raw_summary = j["summary"]
+        except (KeyError, TypeError):
+            raw_summary = ""
+        abstract = str(raw_summary).translate({ord("\n"): " ", ord("\r"): " "})
 
         iso = pub_date_utc.isocalendar()
         key = (iso.year, iso.week)

--- a/src/fetchers/arxiv.py
+++ b/src/fetchers/arxiv.py
@@ -70,6 +70,13 @@ def extract_categories(tags) -> list[str]:
     return [t["term"] for t in tags if "term" in t]
 
 
+def extract_authors(authors) -> str:
+    """Join author names from a feedparser authors list into a `;`-separated string."""
+    if not authors:
+        return ""
+    return ";".join(a["name"] for a in authors if isinstance(a, dict) and a.get("name"))
+
+
 def get_parsed_output(
     response: bytes,
     allowed_categories: set | None = None,
@@ -77,7 +84,8 @@ def get_parsed_output(
 ) -> dict:
     """Parse arXiv Atom XML response into rows grouped by (year, ISO week).
 
-    Row schema: ``[Published, ISOWeek, Updated, ID, Version, Title, Categories]``.
+    Row schema:
+    ``[Published, ISOWeek, Updated, ID, Version, Title, Categories, Authors, Abstract]``.
     Dedup key is ``(ID, Version)`` at indices ``(3, 4)``.
     """
     out: dict = {}
@@ -106,6 +114,9 @@ def get_parsed_output(
             title = title.translate({ord(s): None})
         title = f"'{title}'"
 
+        authors = extract_authors(j.get("authors"))
+        abstract = str(j.get("summary", "")).translate({ord("\n"): " ", ord("\r"): " "})
+
         iso = pub_date_utc.isocalendar()
         key = (iso.year, iso.week)
         out.setdefault(key, []).append(
@@ -117,6 +128,8 @@ def get_parsed_output(
                 version,
                 title,
                 ";".join(categories),
+                authors,
+                abstract,
             ]
         )
     return out

--- a/src/fetchers/biorxiv.py
+++ b/src/fetchers/biorxiv.py
@@ -16,7 +16,7 @@ def parse_biorxiv_json(data: bytes, categories: set | None = None) -> dict:
     """Parse bioRxiv JSON bytes, return dict keyed by (year, week) tuple.
 
     Each value is a list of rows:
-    [Date, ISOWeek, DOI, Version, Category, Title, Authors]
+    [Date, ISOWeek, DOI, Version, Category, Title, Authors, Abstract]
 
     If ``categories`` is a non-empty set, entries whose category is not in the
     set are discarded (case-insensitive match on the bioRxiv category string).
@@ -42,6 +42,7 @@ def parse_biorxiv_json(data: bytes, categories: set | None = None) -> dict:
                 cat,
                 entry.get("title", ""),
                 entry.get("authors", ""),
+                entry.get("abstract", ""),
             ]
         )
     return out

--- a/tests/fetchers/test_arxiv.py
+++ b/tests/fetchers/test_arxiv.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.fetchers.arxiv import (
     build_date_query,
+    extract_authors,
     extract_categories,
     get_parsed_output,
     get_total_results,
@@ -103,26 +104,30 @@ def test_extract_categories_empty_tags():
 # --- get_parsed_output ---
 
 
-def _make_entry(arxiv_id, published, tags):
+def _make_entry(arxiv_id, published, tags, authors=None, summary="Mock abstract."):
     """Create a mock feedparser entry."""
     entry = MagicMock()
-    entry.keys.return_value = ["id", "published", "updated", "title", "tags"]
+    entry.keys.return_value = ["id", "published", "updated", "title", "tags", "authors", "summary"]
     entry.__getitem__ = lambda self, key: {
         "id": f"http://arxiv.org/abs/{arxiv_id}v1",
         "published": published,
         "updated": published,
         "title": "Test Paper",
         "tags": tags,
+        "authors": authors if authors is not None else [{"name": "Doe, J."}],
+        "summary": summary,
     }[key]
     return entry
 
 
-def test_parsed_output_includes_categories_column():
-    """Output rows include categories as last column."""
+def test_parsed_output_includes_categories_authors_abstract():
+    """Output rows include categories, authors, and abstract columns."""
     entry = _make_entry(
         "2603.00001",
         "2026-03-23T17:00:00Z",
         [{"term": "cs.CV"}, {"term": "cs.LG"}],
+        authors=[{"name": "Doe, J."}, {"name": "Roe, R."}],
+        summary="A novel approach.",
     )
     mock_parsed = MagicMock()
     mock_parsed.entries = [entry]
@@ -132,8 +137,38 @@ def test_parsed_output_includes_categories_column():
 
     key = list(result.keys())[0]
     row = result[key][0]
-    assert "cs.CV" in row[-1]
-    assert "cs.LG" in row[-1]
+    assert len(row) == 9
+    assert "cs.CV" in row[6]
+    assert "cs.LG" in row[6]
+    assert row[7] == "Doe, J.;Roe, R."
+    assert row[8] == "A novel approach."
+
+
+def test_extract_authors_handles_empty_and_missing():
+    """extract_authors returns '' for None/empty and skips entries without name."""
+    assert extract_authors(None) == ""
+    assert extract_authors([]) == ""
+    assert extract_authors([{"name": "A"}, {}, {"name": "B"}]) == "A;B"
+
+
+def test_parsed_output_strips_newlines_from_abstract():
+    """Abstract newlines/CRs are flattened to spaces (CSV cleanliness)."""
+    entry = _make_entry(
+        "2603.00002",
+        "2026-03-23T17:00:00Z",
+        [{"term": "cs.CV"}],
+        summary="Line one.\nLine two.\r\nLine three.",
+    )
+    mock_parsed = MagicMock()
+    mock_parsed.entries = [entry]
+
+    with patch("src.fetchers.arxiv.parse", return_value=mock_parsed):
+        result = get_parsed_output(b"mock")
+
+    row = result[list(result.keys())[0]][0]
+    assert "\n" not in row[8]
+    assert "\r" not in row[8]
+    assert row[8] == "Line one. Line two.  Line three."
 
 
 def test_parsed_output_filters_by_allowed_categories():

--- a/tests/fetchers/test_biorxiv.py
+++ b/tests/fetchers/test_biorxiv.py
@@ -21,6 +21,7 @@ FIXTURE_JSON = json.dumps(
                 "category": "neuroscience",
                 "title": "Test Paper One",
                 "authors": "Smith J; Jones A",
+                "abstract": "Abstract one.",
                 "date": "2024-01-15",
             },
             {
@@ -29,6 +30,7 @@ FIXTURE_JSON = json.dumps(
                 "category": "neuroscience",
                 "title": "Test Paper Two",
                 "authors": "Brown B",
+                "abstract": "Abstract two.",
                 "date": "2024-01-16",
             },
         ],
@@ -37,7 +39,7 @@ FIXTURE_JSON = json.dumps(
 
 
 def test_parse_biorxiv_json():
-    """Groups papers by ISO week number."""
+    """Groups papers by ISO week number and includes the abstract column."""
     result = parse_biorxiv_json(FIXTURE_JSON)
     assert isinstance(result, dict)
     assert (2024, 3) in result
@@ -46,6 +48,8 @@ def test_parse_biorxiv_json():
     assert first[0] == "2024-01-15"
     assert first[1] == 3
     assert first[2] == "10.1101/2024.01.15.1234"
+    assert first[7] == "Abstract one."
+    assert len(first) == 8
 
 
 def test_parse_biorxiv_json_filters_by_category():


### PR DESCRIPTION
## Summary
Persist the abstract on every fetched row so downstream consumers (paper-eval pipelines, LLM prefilters) don't need to re-poll the API per DOI. arXiv also now records authors (previously dropped).

## Schema changes
- **bioRxiv / medRxiv**: +Abstract → 8 cols
  `[Date, ISOWeek, DOI, Version, Category, Title, Authors, Abstract]`
- **arXiv**: +Authors, +Abstract → 9 cols
  `[Published, ISOWeek, Updated, ID, Version, Title, Categories, Authors, Abstract]`

Both abstract sources (bioRxiv `abstract`, arXiv `summary`) are already in the existing API responses — **zero extra requests**. arXiv abstracts have `\n`/`\r` collapsed to spaces for CSV cleanliness; bioRxiv abstracts pass through (`csv.writer` handles quoting).

## Compatibility
- Dedup column indices (bioRxiv `(2,3)`, arXiv `(3,4)`) unchanged — new columns append at the end.
- Prune-by-category column (`r[4]` for bioRxiv) unchanged.
- Existing CSVs predating this change keep their narrower schema; the loader and prune functions tolerate mixed widths. A backfill rewrite is out-of-scope for this PR.

## Validation
Dispatched against `feat/abstract-schema` on the downstream consumer fork (`Lambda-Biolab/gha-rxiv-feed-action`) — 3 matrix legs ran cleanly; new bioRxiv rows in `data/biorxiv/2026/21.csv` carry the abstract column populated as expected (see commit `ab96520` on that fork).

## Test plan
- [ ] Ruff/lint green.
- [ ] `pytest` green — existing tests updated, two new tests added (`test_extract_authors_handles_empty_and_missing`, `test_parsed_output_strips_newlines_from_abstract`).
- [ ] Dispatch the workflow on a fork and confirm CSV row widths match the new schema.

Generated with Claude <noreply@anthropic.com>