### PR TITLE
feat(workflow): drive matrix topics/categories from repo variables

### DIFF
--- a/.github/workflows/update-rxiv-feed.yaml
+++ b/.github/workflows/update-rxiv-feed.yaml
@@ -17,12 +17,12 @@ jobs:
         include:
           - server: arxiv
             categories: ""
-            topics: "cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO"
+            topics: ${{ vars.ARXIV_TOPICS || 'cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO' }}
           - server: biorxiv
-            categories: "scientific communication and education"
+            categories: ${{ vars.BIORXIV_CATEGORIES || 'scientific communication and education' }}
             topics: ""
           - server: medrxiv
-            categories: "medical education"
+            categories: ${{ vars.MEDRXIV_CATEGORIES || 'medical education' }}
             topics: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
Move the per-server `topics` / `categories` strings from hardcoded matrix values to GitHub Actions repo variables, with the current upstream defaults preserved via `||` fallback. Same pattern this workflow already uses for `DAYS`.

```yaml
topics: \${{ vars.ARXIV_TOPICS || 'cat:cs.CV+OR+...' }}
categories: \${{ vars.BIORXIV_CATEGORIES || 'scientific communication and education' }}
categories: \${{ vars.MEDRXIV_CATEGORIES || 'medical education' }}
```

## Why
Surfaced by a downstream fork (`Lambda-Biolab/gha-rxiv-feed-action`) that needs broader category sets than upstream's defaults. Two pain points the fork hit:

1. **Sync conflicts** — every upstream change near the matrix block risks conflicting with the fork's locally-modified matrix values.
2. **Feature-branch foot-gun** — branches based on upstream `main` (e.g. for testing a schema change) inherit the narrow defaults, causing `prune_existing_csvs` to drop the fork's broader-category data when dispatched.

Vars solve both: per-repo, branch-agnostic, no file divergence.

## Behavior
- **Upstream**: unchanged — vars are unset, defaults apply.
- **Forks**: set the three vars in *Settings → Secrets and variables → Actions → Variables* to override.
- **Forks' feature branches**: inherit fork-level vars automatically (vars are repo-scoped, not branch-scoped).

## Test plan
- [ ] CI green.
- [ ] Dispatch on a fork without setting vars → confirms defaults apply (matches current behavior).
- [ ] Dispatch on a fork with vars set → confirms override.

Generated with Claude <noreply@anthropic.com>