### PR TITLE
feat(biorxiv): honor DATE_FROM/DATE_TO on bio/med path for backfill

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,10 +31,15 @@ inputs:
     description: "arXiv only: skip papers published more than N days ago."
     default: "7"
   DATE_FROM:
-    description: "arXiv only: YYYY-MM-DD lower bound on submittedDate. Empty = use MAX_AGE_DAYS."
+    description: >-
+      YYYY-MM-DD lower bound. arXiv: bounds submittedDate (empty = use
+      MAX_AGE_DAYS). bioRxiv/medRxiv: overrides the rolling DAYS window
+      (empty = use DAYS). Useful for backfill dispatches.
     default: ""
   DATE_TO:
-    description: "arXiv only: YYYY-MM-DD upper bound on submittedDate. Empty = today."
+    description: >-
+      YYYY-MM-DD upper bound. arXiv: bounds submittedDate (empty = today).
+      bioRxiv/medRxiv: overrides the rolling DAYS window (empty = today).
     default: ""
   PAGE_SIZE:
     description: "arXiv only: results per pagination page."

--- a/src/app.py
+++ b/src/app.py
@@ -40,7 +40,14 @@ _ARXIV_HEADER = [
 _ARXIV_CITATIONS_HEADER = ["Citations", "References", "InfluentialCitations"]
 
 
-def _run_biorxiv(server: str, out_dir: str, days: int, categories: set) -> None:
+def _run_biorxiv(
+    server: str,
+    out_dir: str,
+    days: int,
+    categories: set,
+    date_from: str = "",
+    date_to: str = "",
+) -> None:
     """Fetch bioRxiv / medRxiv weekly stats and write per-week CSVs."""
     pruned = prune_existing_csvs(out_dir, categories)
     if pruned:
@@ -50,7 +57,10 @@ def _run_biorxiv(server: str, out_dir: str, days: int, categories: set) -> None:
 
     base_url = f"https://api.biorxiv.org/details/{server}"
     page_size = 100
-    start_date, end_date = build_date_range(days)
+    start_date, end_date = build_date_range(
+        days, date_from=date_from or None, date_to=date_to or None
+    )
+    print(f"Fetching {server} from {start_date} to {end_date}")
     cursor = 0
     all_weeks: dict = {}
 
@@ -202,6 +212,8 @@ def main() -> None:
             out_dir=out_dir,
             days=int(env.get("DAYS") or "1"),
             categories={c.strip() for c in env.get("CATEGORIES", "").split(",") if c.strip()},
+            date_from=env.get("DATE_FROM", ""),
+            date_to=env.get("DATE_TO", ""),
         )
 
 

--- a/src/fetchers/biorxiv.py
+++ b/src/fetchers/biorxiv.py
@@ -58,14 +58,29 @@ def needs_pagination(messages: list) -> bool:
     return total > count
 
 
-def build_date_range(days: int) -> tuple:
+def build_date_range(
+    days: int,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> tuple:
     """Return (start_date, end_date) as YYYY-MM-DD strings.
 
-    end_date is today; start_date is today minus `days`.
+    Explicit ``date_from``/``date_to`` override the rolling ``days`` window
+    (useful for backfill dispatches). When only one bound is given, the
+    other is derived: missing ``date_to`` defaults to today; missing
+    ``date_from`` is ``date_to`` minus ``days``.
+
+    Both inputs must be ``YYYY-MM-DD`` when set; ``validate_env`` rejects
+    malformed values before this is called.
     """
+    if date_from:
+        end = date_to or date.today().isoformat()
+        return date_from, end
+    if date_to:
+        end_d = date.fromisoformat(date_to)
+        return (end_d - timedelta(days=days)).isoformat(), date_to
     today = date.today()
-    start = today - timedelta(days=days)
-    return start.isoformat(), today.isoformat()
+    return (today - timedelta(days=days)).isoformat(), today.isoformat()
 
 
 def prune_existing_csvs(data_dir: str, categories: set | None) -> int:

--- a/tests/fetchers/test_biorxiv.py
+++ b/tests/fetchers/test_biorxiv.py
@@ -176,3 +176,33 @@ def test_date_range_construction():
     assert start == (today - timedelta(days=7)).isoformat()
     assert end == today.isoformat()
     assert len(start) == 10
+
+
+def test_date_range_explicit_from_and_to_override_days():
+    """Explicit date_from + date_to use the window verbatim, ignoring days."""
+    start, end = build_date_range(999, date_from="2024-01-01", date_to="2024-12-31")
+    assert start == "2024-01-01"
+    assert end == "2024-12-31"
+
+
+def test_date_range_only_from_extends_to_today():
+    """Given only date_from, end defaults to today."""
+    start, end = build_date_range(7, date_from="2024-01-01")
+    assert start == "2024-01-01"
+    assert end == date.today().isoformat()
+
+
+def test_date_range_only_to_derives_from_using_days():
+    """Given only date_to, start is date_to minus days."""
+    start, end = build_date_range(30, date_to="2024-06-30")
+    assert start == "2024-05-31"
+    assert end == "2024-06-30"
+
+
+def test_date_range_empty_strings_treated_as_unset():
+    """Empty strings behave like None (validate_env normalizes None already,
+    but app.py passes through env defaults which can be empty)."""
+    start, end = build_date_range(7, date_from=None, date_to=None)
+    today = date.today()
+    assert start == (today - timedelta(days=7)).isoformat()
+    assert end == today.isoformat()


### PR DESCRIPTION
## Summary

- `build_date_range()` on the bio/med path now accepts optional `date_from`/`date_to`; explicit bounds override the rolling `DAYS` window
- `_run_biorxiv` plumbs them through from env (`DATE_FROM`, `DATE_TO`)
- `action.yaml` descriptions updated — DATE_FROM/DATE_TO are no longer "arXiv only"
- Tests cover all four input combinations (both, from-only, to-only, neither)

## Motivation

The `Abstract` column added in #116 only populates on *new* fetches. Old CSVs keep their narrower 7-column schema. The bio path had no way to dispatch a wide-window run for backfill — DATE_FROM/DATE_TO existed in the env but were ignored. This wires them in.

## Backfill workflow (post-merge)

\`\`\`
gh workflow run update-rxiv-feed.yaml \\
  -f DATE_FROM=2023-01-01 -f DATE_TO=2026-05-24 \\
  -f SERVER=biorxiv -f OUT_DIR=./data/biorxiv \\
  -f CATEGORIES="<existing fork categories>"
\`\`\`

`filter_new_rows` still dedupes by `(DOI, version)`, so this fills *gaps* in coverage — it does NOT rewrite narrow-schema rows in-place. To force a full rewrite, clear the data dir first (a REWRITE flag is out of scope).

## Test plan

- [ ] CI green (lint, test, CodeQL, markdown)
- [ ] New tests cover the four DATE_FROM/DATE_TO combinations
- [ ] Existing `test_date_range_construction` still passes (back-compat: positional `days`-only call works)

Generated with Claude <noreply@anthropic.com>