### PR TITLE
docs: refresh README + CHANGELOG for #115/#116/#117/#118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Abstract column on every CSV row** for arXiv, bioRxiv, and medRxiv;
+  arXiv rows additionally include `Authors`. Both fields are already
+  returned by the existing API calls — zero extra requests. arXiv schema
+  grows 7 → 9 cols (`[Published, ISOWeek, Updated, ID, Version, Title,
+  Categories, Authors, Abstract]`); bio/med grows 7 → 8 cols (trailing
+  `Abstract`). Dedup keys and existing column indices unchanged.
+  Pre-existing CSVs keep their narrower schema; loader and prune
+  tolerate mixed widths (#116).
+- **`DATE_FROM`/`DATE_TO` honored on the bioRxiv/medRxiv path.**
+  Previously declared as "arXiv only" — now overrides the rolling
+  `DAYS` window for bio/med too. Enables wide-window backfill
+  dispatches. `filter_new_rows` still dedupes, so this fills gaps in
+  coverage; rewriting narrow-schema rows requires clearing the data
+  dir first (#118).
+- `scripts/enum_medrxiv_categories.py` — one-off helper to re-enumerate
+  the medRxiv category taxonomy by paginating the `/details/medrxiv/`
+  API until convergence (#115).
+
+### Changed
+
+- **medRxiv category list flipped from "sampled, 29" to "canonical, 51"**
+  in `docs/categories.md`. Re-enumerated over a 2.4-year window
+  (41,446 papers); convergence after a 500-page streak with no new
+  category. Adds 22 categories including emergency medicine, oncology
+  subspecialties (orthopedics, otolaryngology), and palliative
+  medicine. API returns lowercase ASCII; client-side matching is
+  already case-insensitive (#115).
+- **Workflow matrix in `.github/workflows/update-rxiv-feed.yaml` now
+  driven by repo variables.** `vars.ARXIV_TOPICS`,
+  `vars.BIORXIV_CATEGORIES`, `vars.MEDRXIV_CATEGORIES` override the
+  inline defaults when set (mirrors the existing `vars.DAYS` pattern).
+  Defaults preserved exactly — upstream behavior unchanged when vars
+  unset. Forks can broaden categories without source-level divergence
+  by setting Settings → Variables (#117).
+
 ---
 
 ## [0.2.1] - 2026-05-24

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Current schemas:
 CSVs keep their narrower schema; the loader and prune step tolerate
 mixed widths and dedup key indices are unchanged across versions.
 For a one-shot backfill, dispatch with `DATE_FROM`/`DATE_TO` set to a
-wide window — `filter_new_rows` still dedupes, so this fills *gaps* in
+wide window — `filter_new_rows` still dedupes, so this fills _gaps_ in
 coverage. To rewrite narrow-schema rows in place, clear the data
 directory first.
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ steps:
 | `INCLUDE_CITATIONS` | No | `false` | Enrich arXiv rows with Semantic Scholar citation counts. arXiv only. |
 | `SEMANTIC_SCHOLAR_API_KEY` | No | _(empty)_ | Optional Semantic Scholar API key for higher rate limits. arXiv only. |
 | `MAX_AGE_DAYS` | No | `7` | Skip arXiv papers published more than N days ago. Ignored when `DATE_FROM` is set. arXiv only. |
-| `DATE_FROM` | No | _(empty)_ | YYYY-MM-DD lower bound on arXiv `submittedDate`. arXiv only. |
-| `DATE_TO` | No | _(empty)_ | YYYY-MM-DD upper bound on arXiv `submittedDate`. Empty = today. arXiv only. |
+| `DATE_FROM` | No | _(empty)_ | YYYY-MM-DD lower bound. **arXiv**: bounds `submittedDate` (empty uses `MAX_AGE_DAYS`). **bioRxiv/medRxiv**: overrides the rolling `DAYS` window (empty uses `DAYS`). Useful for backfill dispatches. |
+| `DATE_TO` | No | _(empty)_ | YYYY-MM-DD upper bound. Empty = today. Server semantics mirror `DATE_FROM`. |
 | `PAGE_SIZE` | No | `1000` | arXiv pagination page size. arXiv only. |
 | `MAX_PAGES` | No | `5` | Cap on arXiv pagination pages per run. arXiv only. |
 | `DAYS` | No | `1` | Number of days back to fetch. bioRxiv/medRxiv only. |
@@ -114,15 +114,27 @@ the validator boundary. Extend `_ALLOWED_HOSTS` in
 The action appends new rows on each run and dedupes by
 `(DOI, Version)` for bioRxiv/medRxiv or `(ID, Version)` for arXiv.
 
-`data/arxiv/` is pre-populated with 16 historical weekly CSVs migrated
-from [`qte77/gha-arxiv-stats-action-legacy`](https://github.com/qte77/gha-arxiv-stats-action-legacy)
+Current schemas:
+
+- **arXiv** (9 cols): `Published, ISOWeek, Updated, ID, Version, Title, Categories, Authors, Abstract`
+- **bioRxiv / medRxiv** (8 cols): `Date, ISOWeek, DOI, Version, Category, Title, Authors, Abstract`
+
+`Authors`/`Abstract` were added in v0.2.2 (unreleased). Pre-existing
+CSVs keep their narrower schema; the loader and prune step tolerate
+mixed widths and dedup key indices are unchanged across versions.
+For a one-shot backfill, dispatch with `DATE_FROM`/`DATE_TO` set to a
+wide window — `filter_new_rows` still dedupes, so this fills *gaps* in
+coverage. To rewrite narrow-schema rows in place, clear the data
+directory first.
+
+`data/arxiv/` is also pre-populated with 16 historical weekly CSVs
+migrated from [`qte77/gha-arxiv-stats-action-legacy`](https://github.com/qte77/gha-arxiv-stats-action-legacy)
 (formerly `gha-arxiv-stats-action`; archived after the fold-in) when
 this action absorbed its scope (issue #72). The 6 files under
 `data/arxiv/2024/` use a legacy 6-column schema
-(`Published,Weekday,Updated,ID,Version,Title`); files from 2026 onward
-use the current 7-column schema with a trailing `Categories` column.
-The dedup key columns are at the same indices in both schemas, so the
-mixed-schema state is safe; new writes go to current-week files only.
+(`Published,Weekday,Updated,ID,Version,Title`); 2026 files use the
+7-col schema with `Categories`; new writes use the 9-col schema above.
+Dedup key columns are at the same indices across all three.
 
 ## License
 


### PR DESCRIPTION
## Summary

Docs catch-up after today's behavior-changing merges. Two commits, one per file, scoped by topic.

- **CHANGELOG** — fill in `[Unreleased]` with entries for #115 (medRxiv canonical 51 cats + enum script), #116 (Abstract + Authors), #117 (vars-driven matrix), #118 (DATE_FROM/DATE_TO on bio/med path).
- **README** — Inputs table: DATE_FROM/DATE_TO are no longer "arXiv only"; describe the bio/med fallback. Data section: explicit current schemas (8/9 cols), the wide-window backfill pattern + dedupe caveat, and how mixed-schema CSVs coexist safely.

No code changes. No version bump — per the project convention, releases are cut manually and consumers pin `@vX.Y.Z`, so this lands in the next release.

## Test plan

- [ ] CI green (lint, lint/markdown, lint/links)
- [ ] CHANGELOG entries are categorized correctly under Keep-a-Changelog types

Generated with Claude <noreply@anthropic.com>