### PR TITLE
fix(arxiv): drop legacy single-quote title wrapping; preserve apostrophes

### DIFF
--- a/src/fetchers/arxiv.py
+++ b/src/fetchers/arxiv.py
@@ -109,10 +109,7 @@ def get_parsed_output(
         if max_age_days is not None and (now - pub_date_utc).days > max_age_days:
             continue
 
-        title = str(j["title"])
-        for s in "\n\r\"'":
-            title = title.translate({ord(s): None})
-        title = f"'{title}'"
+        title = str(j["title"]).translate({ord("\n"): " ", ord("\r"): " "})
 
         try:
             raw_authors = j["authors"]

--- a/tests/fetchers/test_arxiv.py
+++ b/tests/fetchers/test_arxiv.py
@@ -144,6 +144,37 @@ def test_parsed_output_includes_categories_authors_abstract():
     assert row[8] == "A novel approach."
 
 
+def test_parsed_output_preserves_title_verbatim_without_wrapping_quotes():
+    """The row's Title column is the raw title with newlines collapsed —
+    NOT wrapped in literal single quotes, and apostrophes are preserved.
+    CSV quoting is handled at write time by _write_csv_row in common.py."""
+    entry = _make_entry(
+        "2603.00010",
+        "2026-03-23T17:00:00Z",
+        [{"term": "cs.CV"}],
+    )
+    entry.__getitem__ = lambda self, key: {
+        "id": "http://arxiv.org/abs/2603.00010v1",
+        "published": "2026-03-23T17:00:00Z",
+        "updated": "2026-03-23T17:00:00Z",
+        "title": "O'Brien's algorithm: a survey\nwith newline",
+        "tags": [{"term": "cs.CV"}],
+        "authors": [{"name": "Doe, J."}],
+        "summary": "abs",
+    }[key]
+    mock_parsed = MagicMock()
+    mock_parsed.entries = [entry]
+
+    with patch("src.fetchers.arxiv.parse", return_value=mock_parsed):
+        result = get_parsed_output(b"mock")
+
+    row = result[list(result.keys())[0]][0]
+    title = row[5]
+    assert title == "O'Brien's algorithm: a survey with newline"
+    assert not title.startswith("'")
+    assert not title.endswith("'")
+
+
 def test_extract_authors_handles_empty_and_missing():
     """extract_authors returns '' for None/empty and skips entries without name."""
     assert extract_authors(None) == ""


### PR DESCRIPTION
## Summary

Drops the `f\"'{title}'\"` wrapping in \`src/fetchers/arxiv.py\` that produced \`\"'My Title'\"\` in every arxiv CSV row after #121's RFC-4180 quoting landed. Also stops stripping internal apostrophes and double-quotes from the title — they're preserved verbatim.

Found in run \`26369274263\`: arxiv/2026/21.csv had every title wrapped twice.

## Behavior

- **Before**: title \`O'Brien's algorithm\` → fetcher mangled to \`'OBriens algorithm'\` (apostrophes stripped, then wrapped) → CSV cell \`\"'OBriens algorithm'\"\`
- **After**: title \`O'Brien's algorithm\` → fetcher passes through verbatim (only \`\\n\`/\`\\r\` → space, like the abstract on the next line) → CSV cell \`\"O'Brien's algorithm\"\` (quoted because of whitespace)

## TDD

One new test (\`test_parsed_output_preserves_title_verbatim_without_wrapping_quotes\`) asserts the row's Title column equals the raw input verbatim (with newlines collapsed) — no leading/trailing \`'\`, apostrophes intact.

## Test plan

- [ ] CI green (lint, test, CodeQL, markdown, links)
- [ ] After merge, delete \`data/arxiv/2026/21.csv\` again and re-dispatch — verify titles are clean

Generated with Claude <noreply@anthropic.com>