### PR TITLE
fix(action): guard auto-commit step when OUT_DIR doesn't exist

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -104,6 +104,10 @@ runs:
         OUT_DIR: ${{ inputs.OUT_DIR }}
         REPO: ${{ github.repository }}
       run: |
+        if [ ! -d "$OUT_DIR" ]; then
+          echo "OUT_DIR ($OUT_DIR) does not exist — fetcher wrote nothing (e.g. arXiv probe failure). Skipping commit."
+          exit 0
+        fi
         git add "$OUT_DIR"
         git diff --cached --quiet && echo "No changes. Nothing to do." && exit 0
         DATE=$(date -u +%Y%m%d-%H%M%S)


### PR DESCRIPTION
## Summary
If the fetcher writes nothing — e.g. transient arXiv API probe failure where the run logs `Done. 0 new papers written.` — the auto-commit step runs `git add "$OUT_DIR"` against a non-existent directory and exits 128 with `pathspec did not match any files`. The job fails even though nothing actually went wrong.

## Fix
Early-exit if `$OUT_DIR` doesn't exist on disk, before `git add`. Mirrors the spirit of the existing `git diff --cached --quiet && echo "No changes." && exit 0` line right below it.

## Repro
Observed on downstream `Lambda-Biolab/gha-rxiv-feed-action` dispatch run `26371380094`:
- arxiv leg: probe failure → fetcher exited gracefully → commit step crashed → job marked failed.
- bio/med legs: succeeded normally.

## Test plan
- [ ] Lint/Tests green.
- [ ] Re-dispatch the affected workflow when arXiv API is up — fetch + commit both succeed.
- [ ] Manual cross-check: run a dispatch where the fetcher writes 0 papers (e.g. `MAX_AGE_DAYS=0`) and confirm the job exits 0 with the new "OUT_DIR does not exist" message.

Generated with Claude <noreply@anthropic.com>