### PR TITLE
docs(changelog): generalize downstream-consumer reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Composite action `action.yaml` steps pinned to full-length commit SHAs
   to match the workflow-files policy (consistency with #74 and
   defense-in-depth against upstream tag rewrites). Surfaced by a
-  downstream consumer (Lambda-Biolab fork) whose repo enforces
+  downstream consumer fork whose repo enforces
   `sha_pinning_required: true`. Supersedes #112.
 - `github/codeql-action/{init,autobuild,analyze}` bumped 4.35.4 →
   4.35.5 (SHA `9e0d7b8`). Supersedes #108.


### PR DESCRIPTION
## Summary

Drop \"(Lambda-Biolab fork)\" specifics from the 0.2.1 SHA-pinning CHANGELOG entry. The change applies to any downstream consumer fork that enforces \`sha_pinning_required\`, not just one.

Mirrors Lambda-Biolab fork PR #22.

## Test plan

- [x] Single-line edit, content unchanged otherwise
- [x] Markdown formatting preserved