### PR TITLE
chore(ruff): strict lint config + fix surfaced failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dependencies = ["feedparser>=6.0.12", "requests>=2.32"]
 
 [dependency-groups]
-dev = ["pytest>=9.0.3", "ruff>=0.15.10"]
+dev = ["complexipy>=4.0", "pytest>=9.0.3", "ruff>=0.15.10"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -21,13 +21,44 @@ target-version = "py310"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "S", "C90"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes (unused imports, undefined names)
+    "I",    # isort (import order)
+    "N",    # PEP-8 naming
+    "W",    # pycodestyle warnings
+    "UP",   # pyupgrade (modernize syntax)
+    "B",    # flake8-bugbear (likely bugs)
+    "S",    # flake8-bandit (security)
+    "SIM",  # flake8-simplify
+    "RUF",  # ruff-specific
+    "PT",   # pytest style
+    "ANN",  # flake8-annotations (type hints)
+    "TCH",  # flake8-type-checking (move imports to TYPE_CHECKING)
+    "PGH",  # pygrep-hooks (no broad noqa, etc.)
+    "C90",  # mccabe cyclomatic complexity
+    "D",    # pydocstyle (docstring style)
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]
+"tests/**" = [
+    "S101",    # assert is pytest's idiom
+    "D",       # tests are self-documenting via their names
+    "ANN",     # tests don't require full annotation coverage
+    "PT009",   # unittest-style assertEqual etc. — file mixes unittest + pytest
+    "PT011",   # pytest.raises without `match` is fine for our use
+    "PT027",   # unittest-style assertRaises
+]
+
+[tool.complexipy]
+max-complexity-allowed = 10
+quiet = false
 
 [tool.bumpversion]
 current_version = "0.2.2"

--- a/scripts/enum_medrxiv_categories.py
+++ b/scripts/enum_medrxiv_categories.py
@@ -27,6 +27,7 @@ CONVERGE_AFTER = 500
 
 
 def fetch(cursor: int) -> dict:
+    """Fetch one paginated batch from the medRxiv details API."""
     url = URL.format(start=START, end=END, cursor=cursor)
     r = requests.get(url, timeout=30)
     r.raise_for_status()
@@ -34,6 +35,7 @@ def fetch(cursor: int) -> dict:
 
 
 def main() -> int:
+    """Walk pages until convergence; print sorted distinct categories on stdout."""
     cats: set[str] = set()
     cursor = 0
     streak = 0

--- a/scripts/migrate_csv_schema.py
+++ b/scripts/migrate_csv_schema.py
@@ -1,11 +1,10 @@
-"""Migrate every CSV under ``<data_root>/<server>/<year>/*.csv`` to the
-current canonical header for that server.
+"""Migrate every per-server CSV to the current canonical header.
 
-Driven by the same headers the action writes today (kept in lockstep
-with ``src/app.py`` ``_BIORXIV_HEADER`` / ``_ARXIV_HEADER``). Delegates
-the rewrite to ``src.fetchers.common.upgrade_csv_header`` so the strict
-prefix-safety rule applies uniformly — legacy files with renamed columns
-(e.g. arXiv 2024's ``Weekday`` vs current ``ISOWeek``) are left alone.
+Walks ``<data_root>/<server>/<year>/*.csv`` and delegates each rewrite
+to ``src.fetchers.common.upgrade_csv_header`` so the strict prefix-safety
+rule applies uniformly — legacy files with renamed columns (e.g. arXiv
+2024's ``Weekday`` vs current ``ISOWeek``) are left alone. Headers stay
+in lockstep with ``src/app.py`` ``_BIORXIV_HEADER`` / ``_ARXIV_HEADER``.
 
 Idempotent. Safe to re-run.
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""rxiv-feed-action sources."""

--- a/src/app.py
+++ b/src/app.py
@@ -84,7 +84,7 @@ def _run_biorxiv(
             print(f"Wrote {year}/week {week}: {len(new_rows)} new papers")
 
 
-def _arxiv_paginate(  # noqa: PLR0913 - paginator config requires many parameters
+def _arxiv_paginate(
     base_url: str,
     search_query: str,
     page_size: int,
@@ -124,7 +124,7 @@ def _arxiv_paginate(  # noqa: PLR0913 - paginator config requires many parameter
     return out
 
 
-def _run_arxiv(  # noqa: PLR0913 - aggregates many env-driven knobs
+def _run_arxiv(
     out_dir: str,
     topics: str,
     include_citations: bool,

--- a/src/fetchers/__init__.py
+++ b/src/fetchers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-server preprint fetchers (arXiv, bioRxiv, medRxiv) and shared HTTP/IO."""

--- a/src/fetchers/arxiv.py
+++ b/src/fetchers/arxiv.py
@@ -6,20 +6,21 @@ This module is pure parsing — no network, no I/O at import time.
 """
 
 from datetime import datetime
+from typing import Any
 
 from feedparser import FeedParserDict, parse  # type: ignore[import-untyped]
 
 from src.fetchers.common import scrub_newlines
 
 
-def encode_feedparser_dict(d):
+def encode_feedparser_dict(d: Any) -> Any:  # noqa: ANN401 - heterogeneous feedparser input
     """Strip feedparser objects to plain Python dicts via iterative descent.
 
     Iterative (not recursive) so the function does not trip ruff C901
     under ``mccabe.max-complexity = 10``.
     """
     if isinstance(d, FeedParserDict | dict):
-        return {k: encode_feedparser_dict(d[k]) for k in d.keys()}
+        return {k: encode_feedparser_dict(d[k]) for k in d}
     if isinstance(d, list):
         return [encode_feedparser_dict(x) for x in d]
     return d
@@ -65,14 +66,14 @@ def build_date_query(date_from: str | None = None, date_to: str | None = None) -
     return f"+AND+submittedDate:[{start:%Y%m%d}0000+TO+{end:%Y%m%d}2359]"
 
 
-def extract_categories(tags) -> list[str]:
+def extract_categories(tags: list | None) -> list[str]:
     """Extract arxiv category terms from a feedparser tags list."""
     if not tags:
         return []
     return [t["term"] for t in tags if "term" in t]
 
 
-def extract_authors(authors) -> str:
+def extract_authors(authors: list | None) -> str:
     """Join author names from a feedparser authors list into a `;`-separated string."""
     if not authors:
         return ""
@@ -105,7 +106,7 @@ def get_parsed_output(
         if allowed_categories and not any(c in allowed_categories for c in categories):
             continue
 
-        _idv, rawid, version = parse_arxiv_url(j["id"])
+        _, rawid, version = parse_arxiv_url(j["id"])
         pub_date_utc = datetime.strptime(j["published"], "%Y-%m-%dT%H:%M:%SZ")
 
         if max_age_days is not None and (now - pub_date_utc).days > max_age_days:

--- a/src/fetchers/arxiv_citations.py
+++ b/src/fetchers/arxiv_citations.py
@@ -37,7 +37,8 @@ def get_citations(arxiv_id: str) -> dict:
 
 def enrich_row(row: list, citations: dict) -> list:
     """Append citation_count, reference_count, influential_count to a CSV row."""
-    return row + [
+    return [
+        *row,
         citations["citation_count"],
         citations["reference_count"],
         citations["influential_count"],

--- a/src/fetchers/biorxiv.py
+++ b/src/fetchers/biorxiv.py
@@ -86,9 +86,10 @@ def build_date_range(
 
 
 def prune_existing_csvs(data_dir: str, categories: set | None) -> int:
-    """Rewrite each CSV in data_dir/YYYY/ keeping only rows whose Category is
-    in the set (case-insensitive). Returns total rows removed. No-op when
-    categories is empty/None.
+    """Rewrite each CSV in data_dir/YYYY/ keeping only allowlisted categories.
+
+    Case-insensitive match against ``categories``. Returns total rows
+    removed. No-op when ``categories`` is empty/None.
     """
     if not categories or not exists(data_dir):
         return 0

--- a/src/fetchers/common.py
+++ b/src/fetchers/common.py
@@ -11,6 +11,7 @@ import os
 import time
 from os import makedirs
 from os.path import dirname, exists
+from typing import TextIO
 from urllib.parse import urlparse
 
 import requests
@@ -27,7 +28,7 @@ _ALLOWED_HOSTS = frozenset(
 
 
 def scrub_newlines(value: object) -> str:
-    """Collapse ``\\n``/``\\r`` in a cell to single spaces for CSV cleanliness.
+    r"""Collapse ``\n``/``\r`` in a cell to single spaces for CSV cleanliness.
 
     csv.writer quotes embedded newlines correctly per RFC 4180, but viewers
     that aren't CSV-aware (``cat``, ``wc -l``, GitHub raw blob, plain text
@@ -70,9 +71,12 @@ def get_api_response(url: str, max_retries: int = 3, backoff_base: float = 2.0) 
                 time.sleep(backoff_base**attempt)
             else:
                 raise RuntimeError(f"API failed after {max_retries} attempts: {url}") from None
+    raise RuntimeError(f"API not attempted (max_retries={max_retries}): {url}")
 
 
-def _load_existing_ids(out_file, dedup_cols: tuple[int, int] = (2, 3)):
+def _load_existing_ids(
+    out_file: str, dedup_cols: tuple[int, int] = (2, 3)
+) -> set[tuple[str, str]]:
     """Load set of (id, version) tuples from existing CSV for dedup.
 
     ``dedup_cols`` is a 2-tuple of column indices into each CSV row that
@@ -80,7 +84,7 @@ def _load_existing_ids(out_file, dedup_cols: tuple[int, int] = (2, 3)):
     ``[Date, ISOWeek, DOI, Version, ...]`` schema. Arxiv passes ``(3, 4)``
     for ``[Published, ISOWeek, Updated, ID, Version, ...]``.
     """
-    existing = set()
+    existing: set[tuple[str, str]] = set()
     id_col, ver_col = dedup_cols
     min_len = max(id_col, ver_col) + 1
     if exists(out_file):
@@ -93,9 +97,11 @@ def _load_existing_ids(out_file, dedup_cols: tuple[int, int] = (2, 3)):
     return existing
 
 
-def load_all_existing_ids(data_dir, dedup_cols: tuple[int, int] = (2, 3)):
+def load_all_existing_ids(
+    data_dir: str, dedup_cols: tuple[int, int] = (2, 3)
+) -> set[tuple[str, str]]:
     """Load all dedup keys from CSVs in data_dir/YYYY/ subdirs."""
-    existing = set()
+    existing: set[tuple[str, str]] = set()
     if not exists(data_dir):
         return existing
     for entry in os.listdir(data_dir):
@@ -108,7 +114,9 @@ def load_all_existing_ids(data_dir, dedup_cols: tuple[int, int] = (2, 3)):
     return existing
 
 
-def filter_new_rows(rows, existing_ids, dedup_cols: tuple[int, int] = (2, 3)):
+def filter_new_rows(
+    rows: list[list], existing_ids: set[tuple[str, str]], dedup_cols: tuple[int, int] = (2, 3)
+) -> list[list]:
     """Filter out rows whose dedup key is already in ``existing_ids``."""
     id_col, ver_col = dedup_cols
     return [row for row in rows if (row[id_col], str(row[ver_col])) not in existing_ids]
@@ -132,24 +140,24 @@ def _csv_quote(value: object) -> str:
     return s
 
 
-def _write_csv_row(f, row) -> None:
-    """Write one row using :func:`_csv_quote` per cell, ``\\n`` terminator."""
+def _write_csv_row(f: TextIO, row: list) -> None:
+    r"""Write one row using :func:`_csv_quote` per cell, ``\n`` terminator."""
     f.write(",".join(_csv_quote(c) for c in row))
     f.write("\n")
 
 
 def upgrade_csv_header(out_file: str, new_header: list) -> bool:
-    """Rewrite ``out_file`` so its header matches ``new_header`` when the
-    existing header is a strict prefix of ``new_header``. Pads each data
-    row with empty cells for the added trailing columns.
+    """Rewrite ``out_file`` header to ``new_header`` when safely append-only.
 
-    Safety rule: the existing header must equal ``new_header[:N]`` where
-    N is the existing column count. This means upgrade is only allowed
-    when columns are *appended* — never when an existing column would be
-    semantically renamed (e.g. legacy arXiv ``Weekday`` at col 1 vs
-    current ``ISOWeek``). No-op (returns ``False``) on any mismatch,
-    when the file is missing, or when ``new_header`` is not strictly
-    wider.
+    The existing header must equal ``new_header[:N]`` where N is the
+    existing column count. Pads each data row with empty cells for the
+    added trailing columns.
+
+    Safety rule: upgrade is only allowed when columns are *appended* —
+    never when an existing column would be semantically renamed (e.g.
+    legacy arXiv ``Weekday`` at col 1 vs current ``ISOWeek``). No-op
+    (returns ``False``) on any mismatch, when the file is missing, or
+    when ``new_header`` is not strictly wider.
     """
     if not exists(out_file):
         return False
@@ -172,24 +180,24 @@ def upgrade_csv_header(out_file: str, new_header: list) -> bool:
 
 
 def write_file(
-    content,
-    file_name,
-    out_dir=".",
-    header=None,
+    content: list[list],
+    file_name: str,
+    out_dir: str = ".",
+    header: list[str] | None = None,
     dedup_cols: tuple[int, int] = (2, 3),
-):
-    """Write rows to a CSV file, creating header on first write. Dedupes
-    against existing rows on the ``dedup_cols`` key pair. When a wider
-    ``header`` is passed and the file already has a narrower one, the
-    file is rewritten with the wider header and old rows padded — so a
+) -> None:
+    """Write rows to a CSV file, creating or upgrading the header as needed.
+
+    Dedupes against existing rows on the ``dedup_cols`` key pair. When a
+    wider ``header`` is passed and the file already has a narrower one,
+    the file is rewritten with the wider header and old rows padded — so a
     schema growth (#116: Abstract/Authors) takes effect on appended-to
     CSVs, not just newly created ones.
     """
     out_file = f"{out_dir}/{file_name}.csv"
-    fopen_kw = {"file": out_file, "newline": "", "encoding": "UTF8"}
     if not exists(out_file):
         makedirs(dirname(out_file) if dirname(out_file) else out_dir, exist_ok=True)
-        with open(mode="w+", **fopen_kw) as f:
+        with open(out_file, mode="w+", newline="", encoding="UTF8") as f:
             if header:
                 _write_csv_row(f, header)
     elif header:
@@ -198,6 +206,6 @@ def write_file(
     id_col, ver_col = dedup_cols
     new_rows = [row for row in content if (row[id_col], str(row[ver_col])) not in existing]
     if new_rows:
-        with open(mode="a+", **fopen_kw) as f:
+        with open(out_file, mode="a+", newline="", encoding="UTF8") as f:
             for row in new_rows:
                 _write_csv_row(f, row)

--- a/src/fetchers/common.py
+++ b/src/fetchers/common.py
@@ -74,9 +74,7 @@ def get_api_response(url: str, max_retries: int = 3, backoff_base: float = 2.0) 
     raise RuntimeError(f"API not attempted (max_retries={max_retries}): {url}")
 
 
-def _load_existing_ids(
-    out_file: str, dedup_cols: tuple[int, int] = (2, 3)
-) -> set[tuple[str, str]]:
+def _load_existing_ids(out_file: str, dedup_cols: tuple[int, int] = (2, 3)) -> set[tuple[str, str]]:
     """Load set of (id, version) tuples from existing CSV for dedup.
 
     ``dedup_cols`` is a 2-tuple of column indices into each CSV row that

--- a/tests/fetchers/test_arxiv.py
+++ b/tests/fetchers/test_arxiv.py
@@ -135,7 +135,7 @@ def test_parsed_output_includes_categories_authors_abstract():
     with patch("src.fetchers.arxiv.parse", return_value=mock_parsed):
         result = get_parsed_output(b"mock")
 
-    key = list(result.keys())[0]
+    key = next(iter(result))
     row = result[key][0]
     assert len(row) == 9
     assert "cs.CV" in row[6]
@@ -168,7 +168,7 @@ def test_parsed_output_preserves_title_verbatim_without_wrapping_quotes():
     with patch("src.fetchers.arxiv.parse", return_value=mock_parsed):
         result = get_parsed_output(b"mock")
 
-    row = result[list(result.keys())[0]][0]
+    row = result[next(iter(result))][0]
     title = row[5]
     assert title == "O'Brien's algorithm: a survey with newline"
     assert not title.startswith("'")
@@ -196,7 +196,7 @@ def test_parsed_output_strips_newlines_from_abstract():
     with patch("src.fetchers.arxiv.parse", return_value=mock_parsed):
         result = get_parsed_output(b"mock")
 
-    row = result[list(result.keys())[0]][0]
+    row = result[next(iter(result))][0]
     assert "\n" not in row[8]
     assert "\r" not in row[8]
     assert row[8] == "Line one. Line two.  Line three."

--- a/tests/fetchers/test_arxiv_citations.py
+++ b/tests/fetchers/test_arxiv_citations.py
@@ -56,5 +56,5 @@ def test_enrich_row():
     row = ["2024-06-06T16:20:07Z", 23, "2024-06-07T10:00:00Z", "2406.04221", 1, "'A Title'"]
     citations = {"citation_count": 42, "reference_count": 10, "influential_count": 5}
     result = enrich_row(row, citations)
-    assert result == row + [42, 10, 5]
+    assert result == [*row, 42, 10, 5]
     assert len(result) == len(row) + 3

--- a/tests/fetchers/test_common.py
+++ b/tests/fetchers/test_common.py
@@ -50,10 +50,9 @@ def test_get_api_response_raises_after_max():
             "src.fetchers.common.requests.get",
             side_effect=requests.ConnectionError("fail"),
         ),
-        patch("src.fetchers.common.time.sleep"),
+        patch("src.fetchers.common.time.sleep"),pytest.raises(RuntimeError)
     ):
-        with pytest.raises(RuntimeError):
-            get_api_response("https://api.biorxiv.org/test", max_retries=3)
+        get_api_response("https://api.biorxiv.org/test", max_retries=3)
 
 
 # --- URL validator ---
@@ -85,19 +84,19 @@ def test_validate_url_rejects_non_https(url: str) -> None:
 
 def test_validate_url_rejects_userinfo() -> None:
     """URLs with user:pass@host are rejected to prevent URL-confusion attacks."""
-    with pytest.raises(ValueError, match="[Uu]serinfo"):
+    with pytest.raises(ValueError, match=r"[Uu]serinfo"):
         _validate_url("https://user:pass@api.biorxiv.org/x")
 
 
 def test_validate_url_rejects_fragment() -> None:
     """URLs with a fragment are rejected (defensive against construction bugs)."""
-    with pytest.raises(ValueError, match="[Ff]ragment"):
+    with pytest.raises(ValueError, match=r"[Ff]ragment"):
         _validate_url("https://api.biorxiv.org/x#frag")
 
 
 def test_validate_url_rejects_unknown_host() -> None:
     """Hosts outside the API allowlist are rejected."""
-    with pytest.raises(ValueError, match="[Hh]ost"):
+    with pytest.raises(ValueError, match=r"[Hh]ost"):
         _validate_url("https://evil.example.com/x")
 
 

--- a/tests/fetchers/test_common.py
+++ b/tests/fetchers/test_common.py
@@ -50,7 +50,8 @@ def test_get_api_response_raises_after_max():
             "src.fetchers.common.requests.get",
             side_effect=requests.ConnectionError("fail"),
         ),
-        patch("src.fetchers.common.time.sleep"),pytest.raises(RuntimeError)
+        patch("src.fetchers.common.time.sleep"),
+        pytest.raises(RuntimeError),
     ):
         get_api_response("https://api.biorxiv.org/test", max_retries=3)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,7 +48,8 @@ def test_main_raises_on_invalid_env(monkeypatch):
 
     with (
         patch("src.app._run_arxiv", create=True),
-        patch("src.app._run_biorxiv", create=True),pytest.raises(ValueError, match="SERVER")
+        patch("src.app._run_biorxiv", create=True),
+        pytest.raises(ValueError, match="SERVER"),
     ):
         main()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,10 +48,9 @@ def test_main_raises_on_invalid_env(monkeypatch):
 
     with (
         patch("src.app._run_arxiv", create=True),
-        patch("src.app._run_biorxiv", create=True),
+        patch("src.app._run_biorxiv", create=True),pytest.raises(ValueError, match="SERVER")
     ):
-        with pytest.raises(ValueError, match="SERVER"):
-            main()
+        main()
 
 
 def test_arxiv_paginate_returns_empty_on_probe_failure():

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +135,78 @@ wheels = [
 ]
 
 [[package]]
+name = "complexipy"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/39/a390aa5acccdb5df51c0fbb8cc3b5feba94d86596d78d1257c3624adc7fb/complexipy-5.5.0.tar.gz", hash = "sha256:c6d85ce28c0e8257a0a2caf644b51094438750ee34d6140f9da8859278b70fe5", size = 346876, upload-time = "2026-05-22T19:41:12.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/33/d92e5b18aaada5b664811473970200def38182746551056479fd7bece07c/complexipy-5.5.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:8e956ac59623adbf4dba312adefb238459d8e9b0591731d4cc692df531c057fd", size = 2215322, upload-time = "2026-05-22T19:38:41.484Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c51d960e91f537d0a6943b59594222e07b9b179ccf1808d53339e97f8d9c/complexipy-5.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:576fd72bf7c3959cae04107d056913ac5a7027adbc312f008d271c7940fa7193", size = 2134395, upload-time = "2026-05-22T19:38:43.369Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a8/7b5bcebd16c3075033b2f517d9abe2a5308f5487544a1f9656951b355711/complexipy-5.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f11775da7f12015d30a353554924841ddc60b528e79311ee06c5be6a6c2ce57b", size = 2323616, upload-time = "2026-05-22T19:38:45.392Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/be/94a3776d51f104bca21a73f273438dea552db525cb5f5379327aab5df0d6/complexipy-5.5.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:801fd1bbb07599f729612d08ffd49761554086dcf6d90b9ee8f43f9fab3138e9", size = 2255157, upload-time = "2026-05-22T19:38:46.894Z" },
+    { url = "https://files.pythonhosted.org/packages/29/64/40b8ade92f60adb5541b1ce54b3a315cc48f1bc34a35b8ea05fac786bf73/complexipy-5.5.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:78a67d2e19851e691660ea1b7244c31c925c21e5b038248b152eb63c73027afe", size = 2456230, upload-time = "2026-05-22T19:38:48.909Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/14/773832bdc36250b5d821dc368fa777ae609cba1f32f8be72d4fb831d431a/complexipy-5.5.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c1b63c75c256c679e7ffad451155c0e3e95aa25bf0c43a03401d668afc7eacb0", size = 2709811, upload-time = "2026-05-22T19:38:50.806Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/3a04d7f1d268f78811399c13e40193893c6c39981d719bd70dd703d4bb81/complexipy-5.5.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:f08f84a5027279d3d9786cc5b85dc6c0de12d4144e66d7ae927e341f52c4e868", size = 2474659, upload-time = "2026-05-22T19:38:52.645Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/be/7923b36eff5239b71df0f6acabe15e9cffbf755e379c80799dc62f5524ff/complexipy-5.5.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:441e8bc484ca9a90c347a01af0817fcf60a032625b8d0b6743bc30e10761f7f4", size = 2378383, upload-time = "2026-05-22T19:38:54.334Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1e/07a16ce1b1e8dcae62ffe856e099f17fc2b84fd232c41c8a04dd3186d87b/complexipy-5.5.0-cp310-cp310-win32.whl", hash = "sha256:3fe92c5af3407c268f2ca22c105528f8e2f1d8f10f0d0eae2e9dcdcb34320b7c", size = 1915101, upload-time = "2026-05-22T19:38:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/8c62004906ddc60ef6c46a16786bfe443692cea3e8a5b8d27d47f6d98c68/complexipy-5.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:1d2796665ac80b987011d866b8de2468f7a8e4b3d25c81f856de1fc663285187", size = 53064, upload-time = "2026-05-22T19:38:58.595Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/42/aa85cd651876308f942098e9fa52e8079105844ce57ca0bad3f0a05cecfa/complexipy-5.5.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5cb84ed46a9d77958c4ae8d3251019f5ac700bfe764b929bfb51dfcae8b68a00", size = 2215335, upload-time = "2026-05-22T19:39:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/de47404bede2be38592aa362f6f3c831ac827a1a18c233fe5b42cbc39173/complexipy-5.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:790ccf2d23bd9993545ca547db19b269217f6699ca271042b6117547b18cc78f", size = 2134372, upload-time = "2026-05-22T19:39:01.976Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/b63fa0230f47f0486234d1719eb71f42deb3d0dad4df93b0293c1f61f7e5/complexipy-5.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b337566eb6eddfa1bfec845c51dad99539cbbf7d7a7d83d90b6f3cb15d34e74a", size = 2323679, upload-time = "2026-05-22T19:39:03.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a4/bcfebe60935b7b1b446efcceefef3df34ddc2b92d1425fa36d47887eae14/complexipy-5.5.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:7daae67e3a830a76e925301428d9d3fa1401ca4dd7178568d043928f66f96051", size = 2255221, upload-time = "2026-05-22T19:39:05.432Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/72/1795b2694a6b0ccf4ad9f79f8612774fd09c07e3a64746adb7846e87365d/complexipy-5.5.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8f77e3acfdec6abcae68fae9f83ea1f608956f339242c458f827d3dac7ef45cf", size = 2439420, upload-time = "2026-05-22T19:39:06.852Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/17/d2f8ce1f2c69beb91fa3da59420ab32ccbf88a1da375b4be984a811c11eb/complexipy-5.5.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db58c46350ecf3942704dfbea77b4a1884c21f63a6c5a7fe83e624735fce8248", size = 2709880, upload-time = "2026-05-22T19:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/bc/dc0be399529dd9c291ac303f29cf8ce14e971e679820aeed54a18783c8a3/complexipy-5.5.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5edcae6572e03b2acac9cd6bb6b4be69725b8a8854ccca3ed6bb11420af183bb", size = 2474699, upload-time = "2026-05-22T19:39:10.973Z" },
+    { url = "https://files.pythonhosted.org/packages/77/49/7e477d88b4ed4d98c3f6c38699aad1d3a267b2eb8d6337f0427292a3d5d9/complexipy-5.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4e9033a188508764223d1a586e57abdf14d9942e3359a34efecc66e4255fd24", size = 2378440, upload-time = "2026-05-22T19:39:12.876Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d9/d7fc53a2f8c4f2e362fbc4061460288c8778e1d27cc5eb19e47a08b6cff1/complexipy-5.5.0-cp311-cp311-win32.whl", hash = "sha256:c74311689c284b3cfbff691a4a8cfd508aafdc3fa79e7d9b9d07827fcfdde90a", size = 1915101, upload-time = "2026-05-22T19:39:14.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/60/9cf4e402ab6025c89facf0535ad6e3219f20c128ed251f8a708f693b5519/complexipy-5.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:a46b3e033eb46406bbbc174ce2caa69c0a3142d722b3556a83433218107afc66", size = 2041559, upload-time = "2026-05-22T19:39:15.877Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/ecb3d760a1701877a07336c7f59e4304c9e9be5660143fd4d09428813527/complexipy-5.5.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:23bb9a77e62fb6616abbe42a4eaa8e24d286ea025f6831c8e047787c1f3d7daf", size = 2215455, upload-time = "2026-05-22T19:39:17.545Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0a/10215308e8c50b5263d5af2e3ef3ad16725b12d55c277f205f0a06a69db2/complexipy-5.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3dc03f49d5450329c4edeccb22e4a0859c4236e588e9d07d639d88e2d7431830", size = 2136072, upload-time = "2026-05-22T19:39:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bd/b3fa9c1fe2a882e5b23043b4cec7dc626a37d0d5b722d5e330eff3c7bdf3/complexipy-5.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7c03e3dafcc8f1f99939c51ce490021ab63d554a95460f686e0e98f133ba47c5", size = 2318782, upload-time = "2026-05-22T19:39:21.232Z" },
+    { url = "https://files.pythonhosted.org/packages/04/80/86be609cd41f886f0640227eab380f877d87a227a4ca96a44b7e5b4f2047/complexipy-5.5.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:1c55cc3f3b414750a601113f3e1f6cdcf01131d5e65c2b2c46135d172824ae28", size = 2256143, upload-time = "2026-05-22T19:39:23.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d0/8e617ebc39c0b07cc8f96d6e79d760d1913ab5214cff0f025a2befaf83f1/complexipy-5.5.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:65bedfab6db826a23a3aa3b43fb4fc072c2d950e53678bd97f01122b3b0aeab3", size = 2456436, upload-time = "2026-05-22T19:39:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ca/a2c5d9c28badb5478ec89df3d0c038d1005f8982edc7f322903d10f1b5d0/complexipy-5.5.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:32890f9602e42047e92836f89db87e1fa8160e7ac216b0d3b4e406fa0eb7ae31", size = 2707617, upload-time = "2026-05-22T19:39:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/81/83513e42306dd14dadce03610a3a04ec697aa4f5d64d4e42a39be121c8df/complexipy-5.5.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3099f55afb3c46f7f857b1380d276f68d6607cbb866ff59a652a3676a1ae953c", size = 2468505, upload-time = "2026-05-22T19:39:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/397796d26ef1629f73c5497fc56fed9935b080f292ad1c1bb76a58ffa806/complexipy-5.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:62c8bfba0c618e5a94e2593712a7ce7a9c68a162114e9c84f95c9229c3a6ce76", size = 2375511, upload-time = "2026-05-22T19:39:30.339Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0a/f28a0ca289afc88a7635c82b63862bcb6205d00f795605b17d99fd585072/complexipy-5.5.0-cp312-cp312-win32.whl", hash = "sha256:c4d1512352d468afda78fb771967442d6c7b4fa31028a7cd6f21d2819146932a", size = 1918633, upload-time = "2026-05-22T19:39:31.916Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4e/8d1c3d02fadb6d96e0abe2bd444d5af38a383d4870b0567a7533c9de8c18/complexipy-5.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d7416dcfb63c96d76dc5bf43d1dd275eeaed3aa0ad372c95e71d2367dab0e97d", size = 2043839, upload-time = "2026-05-22T19:39:33.325Z" },
+    { url = "https://files.pythonhosted.org/packages/93/56/359f9ae42bd3bce2b5727f9bd57c75978130dc15e56c10817472c869f158/complexipy-5.5.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:bccd39278271e59216aff1cb3b57a3e9d9a56aef1db9bcc151c10e5011fec730", size = 2215450, upload-time = "2026-05-22T19:39:34.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/24/bbf5ec15869714e7d2ef42f688b0f7782a69cf95ce43704f77ff632bc220/complexipy-5.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f56059ce198bd72fb72c0b92f57529e4ff245f804637dc535c50d0f3d4d0f39f", size = 2136071, upload-time = "2026-05-22T19:39:36.595Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/94/52f7581961a3e376d4410f27300bb9c9b2b9b42e1d42d8208ab29784c57f/complexipy-5.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3ccdbbeb00e25443ee13aa07dce052cd4021302d4b85b749f548f137b4fcc930", size = 2318783, upload-time = "2026-05-22T19:39:38.25Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/0d/4a5a84462dfbe487b6c27f8adb0184e4eb4755fdb0a4b7a1808f48df17aa/complexipy-5.5.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:55d4e2941005838a9dc56e9118d2bd5c3c2d748ce9b07f1ca7578c3a687a1314", size = 2256142, upload-time = "2026-05-22T19:39:39.929Z" },
+    { url = "https://files.pythonhosted.org/packages/04/49/96e977ca0ca764530a6f5613f765e685d3f2b1f1ddd6e4e953271b6580a7/complexipy-5.5.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:784f330a52a309b45cd252a5e1e19cc1f47a31003c5785b2f260bed2be49926f", size = 2456434, upload-time = "2026-05-22T19:39:41.466Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/0c295cc9f2e4b4503cc720d7663eb420588c11a9feba7837083b450b1a27/complexipy-5.5.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:56dec39826804708ef8f0586f738495bb2ef1ff2aded1d77364ab9cc45a97de6", size = 2707618, upload-time = "2026-05-22T19:39:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1e/793f89c4bc06a74fee3176c55808c4037a4465d986947bb5ca5745d2d8c9/complexipy-5.5.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a33f6b6d7a907ece905a0a8e40f56d34876af985cdc4eeed857ed311725e45d2", size = 2468505, upload-time = "2026-05-22T19:39:44.927Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/95debb9a3c3a263b346dbb19590c2088a7d78f7454dbad6f300c4af15802/complexipy-5.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19cf316636e98b6b5cab03e713c89ebf81b46ff01e002c2a8897fc629f78b594", size = 2375512, upload-time = "2026-05-22T19:39:47.148Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/81/1d07a97880cfc72b4ec66e06616a208579abc337d7a1ca532337546b27d7/complexipy-5.5.0-cp313-cp313-win32.whl", hash = "sha256:0cdca6fd5cbad53d215877198ed136f379c71b3ec6ba16ee0dd6c082d5111e58", size = 1918629, upload-time = "2026-05-22T19:39:48.739Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9c/52a7f72e941aa65ef3a48c95486293e0a015649631c56615ae9ba1c0ece9/complexipy-5.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:115cc4be3f13df41e2f7990837096bb84fb7e686c4db35c838dcd068a93dae88", size = 2043837, upload-time = "2026-05-22T19:39:50.514Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b9/5af652ca3c85eeb86707b945a29b38396263359eb4239a33d9f810e83bc6/complexipy-5.5.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:2fa1b99c947567150baee311779381d1844fecf57a1555bbed46f3a68f6286da", size = 2215451, upload-time = "2026-05-22T19:39:52.513Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/20/c32a46a0c40efb07b292902dae291de0358a90005badb29e859277cea392/complexipy-5.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c58f478c5c3971c5d80142a407b3d910eae4f133c3f4f8303adaf3dd022a874a", size = 2136069, upload-time = "2026-05-22T19:39:54.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/ddc0084447c58052aa6808d6fa29fb5200f6b40e3cca4b6537aeea1ceb7a/complexipy-5.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2a5c4b8572b4219e14631553c4c263e44dce292eed737c9bff0a4ed3f6004f3", size = 2318782, upload-time = "2026-05-22T19:39:55.543Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/e44ae2dd6969c77acd942959b05c3a080bf7af6c72e0bbf08d2b70210d26/complexipy-5.5.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:154c16cb15c81f845f21c37daa5e261d531d4f6463bec890d61899b6be24ee7a", size = 2256141, upload-time = "2026-05-22T19:39:57.161Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/2d958617c57de367bbad32c3849be643363f8e9f764494fc993ba9a47f44/complexipy-5.5.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:de8c98e7f8ed44fa9bb327b58e6e5b6acfbf543e7ac07e6f19269393ca5fd794", size = 2456435, upload-time = "2026-05-22T19:39:58.882Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cd/ace41a7f4f7f7c16863b14b342988190386e860bd06abc1801a01f43f8b2/complexipy-5.5.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0006c88baadc3d2e3279660b3e9d2c1dc629a6b40a4e7ae8a7cafe6b968d9cb9", size = 2707617, upload-time = "2026-05-22T19:40:00.747Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/e28417982de8b479261a7c8569dbc9645e6fdfe7c22e49e46d7347f5fd07/complexipy-5.5.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:22de21ec75276c6458192e7c291d162418a6c21071d8226e3447a4da72295cef", size = 2468507, upload-time = "2026-05-22T19:40:02.346Z" },
+    { url = "https://files.pythonhosted.org/packages/68/63/76ea965e721de6ea055f7fd9684e4da7741240bf89b2f86d69774b3e64fa/complexipy-5.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:de60570bf5b968cc50d1554f970bc317893b67923910fac6b35aa38921e2287a", size = 2375512, upload-time = "2026-05-22T19:40:04.288Z" },
+    { url = "https://files.pythonhosted.org/packages/38/28/af04683d10495824ef54555fb4ee666a3e7718c602215215a1857c304bb2/complexipy-5.5.0-cp314-cp314-win32.whl", hash = "sha256:c7714f9ef79479e399f5603e4d5c436ab088210762c46a283f20e6b6d6f4ed3e", size = 1918632, upload-time = "2026-05-22T19:40:05.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/39/2d275b2660b06a6be9ef482d77c1f07fa2cbf091500b05beba55f349fc9f/complexipy-5.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:669702e9b4453cb721845058b1cced8e86f0cfa5139dc574fdfae0aa6b0be11c", size = 2043840, upload-time = "2026-05-22T19:40:07.41Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6f/3f4045ea3aafb0a3d66b5a41dcaeb9b5f4e0e2dc08f568e3b72deed0ee0e/complexipy-5.5.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6ce8be6261cb7e31a656c5961965b356f4d04a79830f54ce714abb76bae648a1", size = 2323801, upload-time = "2026-05-22T19:40:39.976Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/dbc5632e3df5c8a719fb21a489e6806b1e40541532cff696b52c9500b56a/complexipy-5.5.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:6d6c1721416c4c9c90bed860e5345eaaa6c58e48c6230b7c448a170405d7eb67", size = 2255485, upload-time = "2026-05-22T19:40:41.749Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/64/613544650dc549d02d4ec227d05ef502c305801630d80f59107fd93c08e1/complexipy-5.5.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c5967735775e8891ece158ae95b441facb6318ccc3d716c173b13a3368339a8f", size = 2710352, upload-time = "2026-05-22T19:40:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/15/14/d32a88bf29c28550979b7efd71a42c396350febc64cf39da647c16c98bb6/complexipy-5.5.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:09e7cda289cc2c15d3adaca37f31bbf7fa55c4cbb9456f8d1f6e47f215425ef0", size = 2473941, upload-time = "2026-05-22T19:40:45.014Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fe/6426d1cb284d59345bd23ece4b33f208dca157a50f5a286513ef8e125483/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f27ac42332e27c9832673edd25451d4614e702dd1f405e0d3a65dfc50bda2cbe", size = 2323932, upload-time = "2026-05-22T19:40:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/92/19/06c0149de4d711e1e53358be12949b814942e334ed59e9364e062b68ffa6/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:868187d7d13915ddce824d7df1ef871351674d76fd808136d7f19a1408ca9627", size = 2255572, upload-time = "2026-05-22T19:40:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/31/90/eb59d4f58b834ca4eff567b86ae5986020bef2609406b0c69e5d4eec437e/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:061ba79c6965069b30d955574f8ab86a75069fa1cbf1c4bf61113076a10994d6", size = 2456784, upload-time = "2026-05-22T19:40:50.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a9/0c78961f4441ee7bcf3cb7e653796eae74c374cc60d6f7d09d4bf05f95f3/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:77e8a19c40d64b9ea90b53bcf8eeeab5990d28bf0027b9cc4e60d13b8982b28c", size = 2710393, upload-time = "2026-05-22T19:40:52.541Z" },
+    { url = "https://files.pythonhosted.org/packages/85/38/fca125250bfd7b9d433e91fc39e92563185a510ab61be2457a19b2d64639/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cd76fee9efa2ab6df802b6114495a943f33b4d0e3c61e5d5fbcefdb1d9d6c847", size = 2474038, upload-time = "2026-05-22T19:40:54.19Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f1/a7257d752d61657c33e47a792770f222bad88c65f58881dd2ab387e15ec9/complexipy-5.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11612a23d3fd3eef408c70dac5717d01cc356886bd09aaf95873403d5a6997a7", size = 2377453, upload-time = "2026-05-22T19:40:55.699Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -151,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "gha-rxiv-feed-action"
-version = "0.2.0"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "feedparser" },
@@ -160,6 +241,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "complexipy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -172,6 +254,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "complexipy", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.10" },
 ]
@@ -192,6 +275,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -255,6 +359,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
@@ -284,6 +401,15 @@ name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
 
 [[package]]
 name = "tomli"
@@ -337,6 +463,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prerequisite for #107 (arxiv schema rename) per the approved plan at
`~/.claude/plans/generic-percolating-moonbeam.md` § Prerequisite.

Brings feed-action's ruff config to parity with the sibling
`gha-rxiv-paper-eval` strict selection
(`E,F,I,N,W,UP,B,S,SIM,RUF,PT,ANN,TCH,PGH,C90,D` + `pydocstyle = google`)
and adds the matching `complexipy` block + dev dep. All lint failures
surfaced by the new rules are fixed in-place; no runtime behavior change.

## Real bugs surfaced (and fixed) by the new rules

- **`get_api_response` fallthrough**: `-> bytes` return type with an
  unreachable-when-`max_retries=0` code path that implicitly returned
  `None`. Now raises `RuntimeError` explicitly after the retry loop
  (caught by Pyright as `reportReturnType`).
- **`open(**fopen_kw)` overload mis-match**: Pyright couldn't resolve
  the `open()` overload with the splat dict, complaining `str` was
  being passed for `buffering`/`closefd`/`opener`. Spelled out args
  explicitly. Same runtime behavior, no false-positive at type-check.

## Test plan

- [ ] CI green (ruff, tests, codeql, lint/md+links)
- [ ] `get_api_response(url, max_retries=0)` now raises `RuntimeError`
      (would previously fall off the end of the function and return
      `None`, violating the `-> bytes` contract)

The lint-fixes themselves are deliberately not enumerated as test-plan
items per the project rule (see
`~/.claude/projects/.../memory/feedback_only_non_trivial_tests.md` and
the `tdd-core` plugin's "Patterns to Remove" table): items that hold
iff the code merely compiles do not belong in a test plan.

## Out of scope

- No version bump. This is a contributor-experience / dev-tooling
  change with zero consumer impact; reserving the next minor bump
  (`v0.3.0`) for #107's actual breaking schema change.
- No CHANGELOG entry yet — bundle with the next behaviour-changing PR
  per the established value-density preference, OR mention under
  `[Unreleased]` in the #107 PR.

Generated with Claude <noreply@anthropic.com>