### PR TITLE
docs: mark SEMANTIC_SCHOLAR_API_KEY not-yet-implemented; sync roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SEMANTIC_SCHOLAR_API_KEY` input documented honestly.** The README
+  Inputs table advertised it as enabling a higher Semantic Scholar rate
+  limit, but `src/fetchers/arxiv_citations.py` never reads or sends the
+  key (it's a no-op). Marked as not-yet-implemented pending #105.
+
+### Changed
+
+- **`docs/roadmap.md` synced** with current issue state: added the
+  in-flight arXiv schema alignment (#107), bioRxiv/medRxiv citation
+  enrichment (#105), and week-start stub CSV (#134); grouped the
+  OSF-backed fetchers (#70, #99) and flagged chemRxiv (#69) as
+  Cloudflare-blocked.
+
 ---
 
 ## [0.2.2] - 2026-05-31

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ are cut manually; see [`CHANGELOG.md`](CHANGELOG.md) for breaking changes.
 | `OUT_DIR` | No | `./data/arxiv` | Directory to write CSV output files. Convention: `./data/<server>` so multiple servers can coexist when using a matrix. |
 | `TOPICS` | No | `cat:cs.CV+OR+cat:cs.LG+OR+cat:cs.CL+OR+cat:cs.AI+OR+cat:cs.NE+OR+cat:cs.RO` | arXiv search_query (URL-encoded, OR-joined). See [`docs/categories.md`](docs/categories.md#arxiv). arXiv only. |
 | `INCLUDE_CITATIONS` | No | `false` | Enrich arXiv rows with Semantic Scholar citation counts. arXiv only. |
-| `SEMANTIC_SCHOLAR_API_KEY` | No | _(empty)_ | Optional Semantic Scholar API key for higher rate limits. arXiv only. |
+| `SEMANTIC_SCHOLAR_API_KEY` | No | _(empty)_ | Reserved for higher Semantic Scholar rate limits — **not yet implemented** (currently a no-op; the key is not read or sent). Tracked in [#105](https://github.com/qte77/gha-rxiv-feed-action/issues/105). arXiv only. |
 | `MAX_AGE_DAYS` | No | `7` | Skip arXiv papers published more than N days ago. Ignored when `DATE_FROM` is set. arXiv only. |
 | `DATE_FROM` | No | _(empty)_ | YYYY-MM-DD lower bound. **arXiv**: bounds `submittedDate` (empty uses `MAX_AGE_DAYS`). **bioRxiv/medRxiv**: overrides the rolling `DAYS` window (empty uses `DAYS`). Useful for backfill dispatches. |
 | `DATE_TO` | No | _(empty)_ | YYYY-MM-DD upper bound. Empty = today. Server semantics mirror `DATE_FROM`. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,20 +1,38 @@
 # Roadmap
 
 Lightweight tracking of intent. Issues + the milestone view on GitHub
-are the source of truth; this file is the narrative summary.
+are the source of truth; this file is the narrative summary — it holds
+only what issues can't express: sequencing and long-term architectural
+bets.
 
 ## Short-term (in flight)
 
+- **arXiv CSV schema alignment** (`Published`→`Date`, `ID`→`DOI`,
+  `Categories`→`Category`) to match the canonical bioRxiv/medRxiv
+  schema and unblock downstream consumers (paperverse, eval action).
+  Breaking → v0.3.0. Urgent (issue #107).
+- **Citation enrichment for bioRxiv/medRxiv DOIs** via Semantic Scholar
+  `DOI:` lookups — feature parity with arXiv. Also wires the currently
+  no-op `SEMANTIC_SCHOLAR_API_KEY` and routes the call through the URL
+  allowlist (issue #105).
+- **Week-start stub CSV** — publish a header-only CSV on Monday so
+  consumers polling the in-progress week get an empty file, not a 404
+  (issue #134).
 - Backfill arXiv historic weeks 11–19 with the new
   `Authors`+`Abstract` schema — a single `gh workflow run` with
   `date_from`/`date_to` now that #129 and #132 have merged.
 
 ## Medium-term
 
-- **chemRxiv fetcher** — Cloudflare-fronted public API needs a
-  verified UA to bypass the challenge page (issue #69).
-- **psyArXiv fetcher** — OSF taxonomy is depth-1 with 234 nodes;
-  needs a coarse-grouping decision before wiring (`docs/categories.md`).
+- **OSF-backed fetchers (psyArXiv + SocArxiv)** — both ride the same
+  OSF JSON:API substrate (`api.osf.io`), so batch them. Needs a
+  coarse subject-grouping decision (234-node taxonomy) and an
+  authors/N+1 strategy before wiring (issues #70, #99,
+  `docs/categories.md`).
+- **chemRxiv fetcher** — *blocked*: the Figshare/ACS public API is
+  Cloudflare-fronted and returns a challenge page to CI runners, so it
+  can't be fetched or tested unattended. Deferred until an official
+  client or a non-gated endpoint exists (issue #69).
 - **Backfill orchestration helper** — small script that loops
   `gh workflow run` over a series of monthly windows for very long
   backfills (the arXiv API caps at ~50k results per query).


### PR DESCRIPTION
## What

Two doc-accuracy fixes surfaced during a URL/env/CLI documentation audit. **Docs-only — no code changes.**

### 1. Strike the false `SEMANTIC_SCHOLAR_API_KEY` claim
The README Inputs table advertised `SEMANTIC_SCHOLAR_API_KEY` as enabling a higher Semantic Scholar rate limit, but `src/fetchers/arxiv_citations.py:24` calls `requests.get(url, timeout=10)` with **no auth header**, and the var isn't in `_ENV_KEYS` — so setting it does nothing. The row is now marked **not-yet-implemented** and points at #105 (kept in the table so README still mirrors `action.yaml`'s declared inputs).

### 2. Sync `docs/roadmap.md`
It had drifted from the open-issue state. Added the in-flight **#107** (arXiv schema alignment, urgent), **#105** (bio/med citation enrichment), and **#134** (week-start stub CSV); grouped the OSF-backed fetchers **#70 + #99** (shared substrate); flagged **#69** chemRxiv as Cloudflare-blocked/deferred.

## Out of scope (tracked in #105)
The actual Semantic Scholar wiring stays in #105, where the module is already being generalized:
- wire `SEMANTIC_SCHOLAR_API_KEY` → `x-api-key` header (makes this claim true again)
- route the SS call through `get_api_response`/`_validate_url` (restores the `docs/architecture.md` allowlist invariants)

## Verification
- `markdownlint` — no new violations (only pre-existing, non-enforced MD013 line-length on table rows)
- `lychee --config lychee.toml` — 29/29 links OK, including the new #105 link

Generated with Claude <noreply@anthropic.com>