### PR TITLE
fix(release): authenticate bump-version push (#167)

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,7 +55,9 @@ jobs:
           git config user.email "bump-my-version@qte77.gha"
           git checkout -b "$BRANCH"
           git commit -am "chore(release): bump $PREV_VERSION -> $VERSION"
-          git push origin "$BRANCH"
+          # The bump-my-version Docker action disrupts the persisted git
+          # credential, so push to an explicitly token-authenticated URL.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH"
           gh pr create \
             --base "$BASE" \
             --head "$BRANCH" \


### PR DESCRIPTION
Follow-up to #168. The post-merge release dry-run (run 28304829962) failed at the push step:

```
[bump-1-main 2727233] chore(release): bump 0.2.3 -> 0.2.4   # commit OK
fatal: could not read Username for 'https://github.com': No such device or address
```

**Cause:** the `callowayproject/bump-my-version` Docker action runs between `actions/checkout` and the `git push`, disrupting checkout's persisted git credential, so the push has no auth. (paperverse avoids this by running bump-my-version on the host via `uv`, not as a Docker action.)

**Fix:** push to an explicitly token-authenticated URL (`https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git`) — one line, keeps the existing Docker-action bump mechanism. `actionlint` clean.

The failed run pushed nothing (push failed before creating the branch/PR), so the remote and `main` are untouched.

Generated with Claude <noreply@anthropic.com>